### PR TITLE
Adds support for 64-bit integer and some float operations for 32-bit x86...

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -13,6 +13,13 @@ OpenLibm library from msun, as part of the Julia project is covered
 under the MIT license. The test files, test-double.c and test-float.c
 are under the LGPL.
 
+Additional code is due to the LLVM project''s compiler_rt project, which
+is dual licensed under both the University of Illinois "BSD-Like" license
+and the MIT license. As a contributor, you agree to allow your modifications to
+those files used under either license, while users may use thi scode under
+either license. The full text of these licenses is appended to the end of
+this file.
+
 ## Parts copyrighted by the Julia project (MIT License)
 
 >       Copyright (c) 2011-14 The Julia Project.
@@ -113,3 +120,108 @@ are under the LGPL.
 >   License along with the GNU C Library; if not, write to the Free
 >   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
 >   02111-1307 USA.
+
+## LLVM (University of Illinois, BSD-like)
+
+> University of Illinois/NCSA
+> Open Source License
+>
+> Copyright (c) 2009-2014 by the contributors listed below.
+>
+> All rights reserved.
+>
+> Developed by:
+>
+>     LLVM Team
+>
+>     University of Illinois at Urbana-Champaign
+>
+>     http://llvm.org
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of
+> this software and associated documentation files (the "Software"), to deal with
+> the Software without restriction, including without limitation the rights to
+> use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+> of the Software, and to permit persons to whom the Software is furnished to do
+> so, subject to the following conditions:
+>
+>     * Redistributions of source code must retain the above copyright notice,
+>       this list of conditions and the following disclaimers.
+>
+>     * Redistributions in binary form must reproduce the above copyright notice,
+>       this list of conditions and the following disclaimers in the
+>       documentation and/or other materials provided with the distribution.
+>
+>     * Neither the names of the LLVM Team, University of Illinois at
+>       Urbana-Champaign, nor the names of its contributors may be used to
+>       endorse or promote products derived from this Software without specific
+>       prior written permission.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+> FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+> CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+> SOFTWARE.
+
+## LLVM (MIT)
+
+> Copyright (c) 2009-2014 by the contributors listed below
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
+## LLVM (Contributors)
+
+> This file is a partial list of people who have contributed to the LLVM/CompilerRT
+> project.  If you have contributed a patch or made some other contribution to
+> LLVM/CompilerRT, please submit a patch to this file to add yourself, and it will be
+> done!
+>
+> The list is sorted by surname and formatted to allow easy grepping and
+> beautification by scripts.  The fields are: name (N), email (E), web-address
+> (W), PGP key ID and fingerprint (P), description (D), and snail-mail address
+> (S).
+>
+> N: Craig van Vliet
+> E: cvanvliet@auroraux.org
+> W: http://www.auroraux.org
+> D: Code style and Readability fixes.
+>
+> N: Edward O'Callaghan
+> E: eocallaghan@auroraux.org
+> W: http://www.auroraux.org
+> D: CMake'ify Compiler-RT build system
+> D: Maintain Solaris & AuroraUX ports of Compiler-RT
+>
+> N: Howard Hinnant
+> E: hhinnant@apple.com
+> D: Architect and primary author of compiler-rt
+>
+> N: Guan-Hong Liu
+> E: koviankevin@hotmail.com
+> D: IEEE Quad-precision functions
+>
+> N: Joerg Sonnenberger
+> E: joerg@NetBSD.org
+> D: Maintains NetBSD port.
+>
+> N: Matt Thomas
+> E: matt@NetBSD.org
+> D: ARM improvements.

--- a/i387/Make.files
+++ b/i387/Make.files
@@ -20,3 +20,7 @@ $(CUR_SRCS)+= e_remainderl.S e_sqrtl.S s_ceill.S s_copysignl.S \
 	    s_logbl.S s_lrintl.S s_remquol.S s_rintl.S s_truncl.S
 
 $(CUR_SRCS)+= fenv.c
+
+$(CUR_SRCS)+= ashldi3.S ashrdi3.S divdi3.S floatdidf.S floatdisf.S \
+        floatdixf.S floatundidf.S floatundisf.S floatundixf.S      \
+        lshrdi3.S moddi3.S muldi3.S udivdi3.S umoddi3.S fixunsdfdi.c

--- a/i387/ashldi3.S
+++ b/i387/ashldi3.S
@@ -1,0 +1,58 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// di_int __ashldi3(di_int input, int count);
+
+// This routine has some extra memory traffic, loading the 64-bit input via two
+// 32-bit loads, then immediately storing it back to the stack via a single 64-bit
+// store.  This is to avoid a write-small, read-large stall.
+// However, if callers of this routine can be safely assumed to store the argument
+// via a 64-bt store, this is unnecessary memory traffic, and should be avoided.
+// It can be turned off by defining the TRUST_CALLERS_USE_64_BIT_STORES macro.
+
+#ifdef __i386__
+#ifdef __SSE2__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__ashldi3)
+	movd	  12(%esp),		%xmm2	// Load count
+#ifndef TRUST_CALLERS_USE_64_BIT_STORES
+	movd	   4(%esp),		%xmm0
+	movd	   8(%esp),		%xmm1
+	punpckldq	%xmm1,		%xmm0	// Load input
+#else
+	movq	   4(%esp),		%xmm0	// Load input
+#endif
+	psllq		%xmm2,		%xmm0	// shift input by count
+	movd		%xmm0,		%eax
+	psrlq		$32,		%xmm0
+	movd		%xmm0,		%edx
+	ret
+END_COMPILERRT_FUNCTION(__ashldi3)
+
+#else // Use GPRs instead of SSE2 instructions, if they aren't available.
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__ashldi3)
+	movl	  12(%esp),		%ecx	// Load count
+	movl	   8(%esp),		%edx	// Load high
+	movl	   4(%esp),		%eax	// Load low
+
+	testl		$0x20,		%ecx	// If count >= 32
+	jnz		1f			//    goto 1
+	shldl		%cl, %eax,	%edx	// left shift high by count
+	shll		%cl,		%eax	// left shift low by count
+	ret
+
+1:	movl		%eax,		%edx	// Move low to high
+	xorl		%eax,		%eax	// clear low
+	shll		%cl,		%edx	// shift high by count - 32
+	ret
+END_COMPILERRT_FUNCTION(__ashldi3)
+
+#endif // __SSE2__
+#endif // __i386__

--- a/i387/ashrdi3.S
+++ b/i387/ashrdi3.S
@@ -1,0 +1,69 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// di_int __ashrdi3(di_int input, int count);
+
+#ifdef __i386__
+#ifdef __SSE2__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__ashrdi3)
+	movd	  12(%esp),		%xmm2	// Load count
+	movl	   8(%esp),		%eax
+#ifndef TRUST_CALLERS_USE_64_BIT_STORES
+	movd	   4(%esp),		%xmm0
+	movd	   8(%esp),		%xmm1
+	punpckldq	%xmm1,		%xmm0	// Load input
+#else
+	movq	   4(%esp),		%xmm0	// Load input
+#endif
+
+	psrlq		%xmm2,		%xmm0	// unsigned shift input by count
+	
+	testl		%eax,		%eax	// check the sign-bit of the input
+	jns			1f					// early out for positive inputs
+	
+	// If the input is negative, we need to construct the shifted sign bit
+	// to or into the result, as xmm does not have a signed right shift.
+	pcmpeqb		%xmm1,		%xmm1	// -1ULL
+	psrlq		$58,		%xmm1	// 0x3f
+	pandn		%xmm1,		%xmm2	// 63 - count
+	pcmpeqb		%xmm1,		%xmm1	// -1ULL
+	psubq		%xmm1,		%xmm2	// 64 - count
+	psllq		%xmm2,		%xmm1	// -1 << (64 - count) = leading sign bits
+	por			%xmm1,		%xmm0
+	
+	// Move the result back to the general purpose registers and return
+1:	movd		%xmm0,		%eax
+	psrlq		$32,		%xmm0
+	movd		%xmm0,		%edx
+	ret
+END_COMPILERRT_FUNCTION(__ashrdi3)
+
+#else // Use GPRs instead of SSE2 instructions, if they aren't available.
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__ashrdi3)
+	movl	  12(%esp),		%ecx	// Load count
+	movl	   8(%esp),		%edx	// Load high
+	movl	   4(%esp),		%eax	// Load low
+	
+	testl		$0x20,		%ecx	// If count >= 32
+	jnz			1f					//    goto 1
+
+	shrdl		%cl, %edx,	%eax	// right shift low by count
+	sarl		%cl,		%edx	// right shift high by count
+	ret
+	
+1:	movl		%edx,		%eax	// Move high to low
+	sarl		$31,		%edx	// clear high
+	sarl		%cl,		%eax	// shift low by count - 32
+	ret
+END_COMPILERRT_FUNCTION(__ashrdi3)
+
+#endif // __SSE2__
+#endif // __i386__

--- a/i387/assembly.h
+++ b/i387/assembly.h
@@ -1,0 +1,146 @@
+/* ===-- assembly.h - compiler-rt assembler support macros -----------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file defines macros for use in compiler-rt assembler source.
+ * This file is not part of the interface of this library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef COMPILERRT_ASSEMBLY_H
+#define COMPILERRT_ASSEMBLY_H
+
+#if defined(__POWERPC__) || defined(__powerpc__) || defined(__ppc__)
+#define SEPARATOR @
+#else
+#define SEPARATOR ;
+#endif
+
+#if defined(__APPLE__)
+#define HIDDEN(name) .private_extern name
+#define LOCAL_LABEL(name) L_##name
+// tell linker it can break up file at label boundaries
+#define FILE_LEVEL_DIRECTIVE .subsections_via_symbols
+#define SYMBOL_IS_FUNC(name)
+#elif defined(__ELF__)
+#define HIDDEN(name) .hidden name
+#define LOCAL_LABEL(name) .L_##name
+#define FILE_LEVEL_DIRECTIVE
+#if defined(__arm__)
+#define SYMBOL_IS_FUNC(name) .type name,%function
+#else
+#define SYMBOL_IS_FUNC(name) .type name,@function
+#endif
+#else
+#define HIDDEN_DIRECTIVE(name)
+#define LOCAL_LABEL(name) .L ## name
+#define SYMBOL_IS_FUNC(name)                                                   \
+  .def name SEPARATOR                                                          \
+    .scl 2 SEPARATOR                                                           \
+    .type 32 SEPARATOR                                                         \
+  .endef
+#define FILE_LEVEL_DIRECTIVE
+#endif
+
+#if defined(__arm__)
+#ifndef __ARM_ARCH
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) ||                     \
+    defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) ||                    \
+    defined(__ARM_ARCH_7EM__)
+#define __ARM_ARCH 7
+#endif
+#endif
+
+#ifndef __ARM_ARCH
+#if defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) ||                     \
+    defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) ||                    \
+    defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6ZM__)
+#define __ARM_ARCH 6
+#endif
+#endif
+
+#ifndef __ARM_ARCH
+#if defined(__ARM_ARCH_5__) || defined(__ARM_ARCH_5T__) ||                     \
+    defined(__ARM_ARCH_5TE__) || defined(__ARM_ARCH_5TEJ__)
+#define __ARM_ARCH 5
+#endif
+#endif
+
+#ifndef __ARM_ARCH
+#define __ARM_ARCH 4
+#endif
+
+#if defined(__ARM_ARCH_4T__) || __ARM_ARCH >= 5
+#define ARM_HAS_BX
+#endif
+#if !defined(__ARM_FEATURE_CLZ) &&                                             \
+    (__ARM_ARCH >= 6 || (__ARM_ARCH == 5 && !defined(__ARM_ARCH_5__)))
+#define __ARM_FEATURE_CLZ
+#endif
+
+#ifdef ARM_HAS_BX
+#define JMP(r) bx r
+#define JMPc(r, c) bx##c r
+#else
+#define JMP(r) mov pc, r
+#define JMPc(r, c) mov##c pc, r
+#endif
+#endif
+
+#define GLUE2(a, b) a##b
+#define GLUE(a, b) GLUE2(a, b)
+#define SYMBOL_NAME(name) GLUE(__USER_LABEL_PREFIX__, name)
+
+#ifdef VISIBILITY_HIDDEN
+#define DECLARE_SYMBOL_VISIBILITY(name)                                        \
+  HIDDEN(SYMBOL_NAME(name)) SEPARATOR
+#else
+#define DECLARE_SYMBOL_VISIBILITY(name)
+#endif
+
+#define DEFINE_COMPILERRT_FUNCTION(name)                                       \
+  FILE_LEVEL_DIRECTIVE SEPARATOR                                               \
+  .globl SYMBOL_NAME(name) SEPARATOR                                           \
+  SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
+  DECLARE_SYMBOL_VISIBILITY(name)                                              \
+  SYMBOL_NAME(name):
+
+#define DEFINE_COMPILERRT_PRIVATE_FUNCTION(name)                               \
+  FILE_LEVEL_DIRECTIVE SEPARATOR                                               \
+  .globl SYMBOL_NAME(name) SEPARATOR                                           \
+  SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
+  HIDDEN(SYMBOL_NAME(name)) SEPARATOR                                          \
+  SYMBOL_NAME(name):
+
+#define DEFINE_COMPILERRT_PRIVATE_FUNCTION_UNMANGLED(name)                     \
+  .globl name SEPARATOR                                                        \
+  SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+  HIDDEN(name) SEPARATOR                                                       \
+  name:
+
+#define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+  .globl SYMBOL_NAME(name) SEPARATOR                                           \
+  SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
+  .set SYMBOL_NAME(name), SYMBOL_NAME(target) SEPARATOR
+
+#if defined(__ARM_EABI__)
+#define DEFINE_AEABI_FUNCTION_ALIAS(aeabi_name, name)                          \
+  DEFINE_COMPILERRT_FUNCTION_ALIAS(aeabi_name, name)
+#else
+#define DEFINE_AEABI_FUNCTION_ALIAS(aeabi_name, name)
+#endif
+
+#ifdef __ELF__
+#define END_COMPILERRT_FUNCTION(name)                                          \
+  .size SYMBOL_NAME(name), . - SYMBOL_NAME(name)
+#else
+#define END_COMPILERRT_FUNCTION(name)
+#endif
+
+#endif /* COMPILERRT_ASSEMBLY_H */

--- a/i387/divdi3.S
+++ b/i387/divdi3.S
@@ -1,0 +1,162 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// di_int __divdi3(di_int a, di_int b);
+
+// result = a / b.
+// both inputs and the output are 64-bit signed integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+// Stephen Canon, December 2008
+
+#ifdef __i386__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__divdi3)
+
+/* This is currently implemented by wrapping the unsigned divide up in an absolute
+   value, then restoring the correct sign at the end of the computation.  This could
+   certainly be improved upon. */
+
+	pushl		%esi
+	movl	 20(%esp),			%edx	// high word of b
+	movl	 16(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (b < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (b < 0) ? not(b) : b
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(b)
+	movl		%edx,		 20(%esp)
+	movl		%eax,		 16(%esp)	// store abs(b) back to stack
+	movl		%ecx,			%esi	// set aside sign of b
+	
+	movl	 12(%esp),			%edx	// high word of b
+	movl	  8(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (a < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (a < 0) ? not(a) : a
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(a)
+	movl		%edx,		 12(%esp)
+	movl		%eax,		  8(%esp)	// store abs(a) back to stack
+	xorl		%ecx,			%esi	// sign of result = (sign of a) ^ (sign of b)
+
+	pushl		%ebx
+	movl	 24(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+	
+	/* High word of b is known to be non-zero on this branch */
+	
+	movl	 20(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+	
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 16(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	 12(%esp),			%eax	// to [1] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			1f						
+		
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+	
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	retl								// Return
+
+
+1:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	 
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+	
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	retl								// Return
+
+	
+9:	/* High word of b is zero on this branch */
+
+	movl	 16(%esp),			%eax	// Find qhi and rhi such that
+	movl	 20(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	 12(%esp),			%eax	// Find qlo such that
+	divl		%ecx					//
+	movl		%ebx,			%edx	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+	
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%ebx					// Restore callee-save registers
+	popl		%esi
+	retl								// Return
+END_COMPILERRT_FUNCTION(__divdi3)
+
+#endif // __i386__

--- a/i387/fixunsdfdi.c
+++ b/i387/fixunsdfdi.c
@@ -1,0 +1,47 @@
+/* ===-- fixunsdfdi.c - Implement __fixunsdfdi -----------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __fixunsdfdi for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#include "int_lib.h"
+
+/* Returns: convert a to a unsigned long long, rounding toward zero.
+ *          Negative values all become zero.
+ */
+
+/* Assumption: double is a IEEE 64 bit floating point type 
+ *             du_int is a 64 bit integral type
+ *             value in double is representable in du_int or is negative 
+ *                 (no range checking performed)
+ */
+
+/* seee eeee eeee mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm */
+
+ARM_EABI_FNALIAS(d2ulz, fixunsdfdi)
+
+COMPILER_RT_ABI du_int
+__fixunsdfdi(double a)
+{
+    double_bits fb;
+    fb.f = a;
+    int e = ((fb.u.s.high & 0x7FF00000) >> 20) - 1023;
+    if (e < 0 || (fb.u.s.high & 0x80000000))
+        return 0;
+    udwords r;
+    r.s.high = (fb.u.s.high & 0x000FFFFF) | 0x00100000;
+    r.s.low = fb.u.s.low;
+    if (e > 52)
+        r.all <<= (e - 52);
+    else
+        r.all >>= (52 - e);
+    return r.all;
+}

--- a/i387/floatdidf.S
+++ b/i387/floatdidf.S
@@ -1,0 +1,36 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// double __floatundidf(du_int a);
+
+#ifdef __i386__
+
+#ifndef __ELF__
+.const
+#endif
+.balign 4
+twop52: .quad 0x4330000000000000
+twop32: .quad 0x41f0000000000000
+
+#define REL_ADDR(_a)	(_a)-0b(%eax)
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__floatdidf)
+	cvtsi2sd	8(%esp),			%xmm1
+	movss		4(%esp),			%xmm0 // low 32 bits of a
+	calll		0f
+0:	popl		%eax
+	mulsd		REL_ADDR(twop32),	%xmm1 // a_hi as a double (without rounding)
+	movsd		REL_ADDR(twop52),	%xmm2 // 0x1.0p52
+	subsd		%xmm2,				%xmm1 // a_hi - 0x1p52 (no rounding occurs)
+	orpd		%xmm2,				%xmm0 // 0x1p52 + a_lo (no rounding occurs)
+	addsd		%xmm1,				%xmm0 // a_hi + a_lo   (round happens here)
+	movsd		%xmm0,			   4(%esp)
+	fldl	   4(%esp)
+	ret
+END_COMPILERRT_FUNCTION(__floatdidf)
+
+#endif // __i386__

--- a/i387/floatdisf.S
+++ b/i387/floatdisf.S
@@ -1,0 +1,32 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// float __floatdisf(di_int a);
+
+// This routine has some extra memory traffic, loading the 64-bit input via two
+// 32-bit loads, then immediately storing it back to the stack via a single 64-bit
+// store.  This is to avoid a write-small, read-large stall.
+// However, if callers of this routine can be safely assumed to store the argument
+// via a 64-bt store, this is unnecessary memory traffic, and should be avoided.
+// It can be turned off by defining the TRUST_CALLERS_USE_64_BIT_STORES macro.
+
+#ifdef __i386__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__floatdisf)
+#ifndef TRUST_CALLERS_USE_64_BIT_STORES
+	movd		4(%esp),	%xmm0
+	movd		8(%esp),	%xmm1
+	punpckldq	%xmm1,		%xmm0
+	movq		%xmm0,		4(%esp)
+#endif
+	fildll		4(%esp)
+	fstps		4(%esp)
+	flds		4(%esp)
+	ret
+END_COMPILERRT_FUNCTION(__floatdisf)
+
+#endif // __i386__

--- a/i387/floatdixf.S
+++ b/i387/floatdixf.S
@@ -1,0 +1,30 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// float __floatdixf(di_int a);
+
+#ifdef __i386__
+
+// This routine has some extra memory traffic, loading the 64-bit input via two
+// 32-bit loads, then immediately storing it back to the stack via a single 64-bit
+// store.  This is to avoid a write-small, read-large stall.
+// However, if callers of this routine can be safely assumed to store the argument
+// via a 64-bt store, this is unnecessary memory traffic, and should be avoided.
+// It can be turned off by defining the TRUST_CALLERS_USE_64_BIT_STORES macro.
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__floatdixf)
+#ifndef TRUST_CALLERS_USE_64_BIT_STORES
+	movd		4(%esp),	%xmm0
+	movd		8(%esp),	%xmm1
+	punpckldq	%xmm1,		%xmm0
+	movq		%xmm0,		4(%esp)
+#endif
+	fildll		4(%esp)
+	ret
+END_COMPILERRT_FUNCTION(__floatdixf)
+
+#endif // __i386__

--- a/i387/floatundidf.S
+++ b/i387/floatundidf.S
@@ -1,0 +1,47 @@
+//===-- floatundidf.S - Implement __floatundidf for i386 ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floatundidf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "assembly.h"
+
+// double __floatundidf(du_int a);
+
+#ifdef __i386__
+
+#ifndef __ELF__
+.const
+#endif
+.balign 4
+twop52: .quad 0x4330000000000000
+twop84_plus_twop52:
+		.quad 0x4530000000100000
+twop84: .quad 0x4530000000000000
+
+#define REL_ADDR(_a)	(_a)-0b(%eax)
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__floatundidf)
+	movss	8(%esp),						%xmm1 // high 32 bits of a
+	movss	4(%esp),						%xmm0 // low 32 bits of a
+	calll	0f
+0:	popl	%eax
+	orpd	REL_ADDR(twop84),				%xmm1 // 0x1p84 + a_hi (no rounding occurs)
+	subsd	REL_ADDR(twop84_plus_twop52),	%xmm1 // a_hi - 0x1p52 (no rounding occurs)
+	orpd	REL_ADDR(twop52),				%xmm0 // 0x1p52 + a_lo (no rounding occurs)
+	addsd	%xmm1,							%xmm0 // a_hi + a_lo   (round happens here)
+	movsd	%xmm0,						   4(%esp)
+	fldl   4(%esp)
+	ret
+END_COMPILERRT_FUNCTION(__floatundidf)
+
+#endif // __i386__

--- a/i387/floatundisf.S
+++ b/i387/floatundisf.S
@@ -1,0 +1,99 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// float __floatundisf(du_int a);
+
+// Note that there is a hardware instruction, fildll, that does most of what
+// this function needs to do.  However, because of our ia32 ABI, it will take
+// a write-small read-large stall, so the software implementation here is
+// actually several cycles faster.
+
+// This is a branch-free implementation.  A branchy implementation might be
+// faster for the common case if you know something a priori about the input
+// distribution.
+
+/* branch-free x87 implementation - one cycle slower than without x87.
+
+#ifdef __i386__
+
+.const
+.balign 3
+
+		.quad	0x43f0000000000000
+twop64:	.quad	0x0000000000000000
+
+#define			TWOp64			twop64-0b(%ecx,%eax,8)
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__floatundisf)
+	movl		8(%esp),		%eax
+	movd		8(%esp),		%xmm1
+	movd		4(%esp),		%xmm0
+	punpckldq	%xmm1,			%xmm0
+	calll		0f
+0:	popl		%ecx
+	sarl		$31,			%eax
+	movq		%xmm0,			4(%esp)
+	fildll		4(%esp)
+	faddl		TWOp64
+	fstps		4(%esp)
+	flds		4(%esp)
+	ret
+END_COMPILERRT_FUNCTION(__floatundisf)
+
+#endif // __i386__
+
+*/
+
+/* branch-free, x87-free implementation - faster at the expense of code size */
+
+#ifdef __i386__
+
+#ifndef __ELF__
+.const
+#endif
+.balign 8
+twop52: .quad 0x4330000000000000
+		.quad 0x0000000000000fff
+sticky: .quad 0x0000000000000000
+		.long 0x00000012
+twelve:	.long 0x00000000
+
+#define			TWOp52			twop52-0b(%ecx)
+#define			STICKY			sticky-0b(%ecx,%eax,8)
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__floatundisf)
+	movl		8(%esp),		%eax
+	movd		8(%esp),		%xmm1
+	movd		4(%esp),		%xmm0
+	punpckldq	%xmm1,			%xmm0
+	
+	calll		0f
+0:	popl		%ecx
+	shrl		%eax					// high 31 bits of input as sint32
+	addl		$0x7ff80000,	%eax
+	sarl		$31,			%eax	// (big input) ? -1 : 0
+	movsd		STICKY,			%xmm1	// (big input) ? 0xfff : 0
+	movl		$12,			%edx
+	andl		%eax,			%edx	// (big input) ? 12 : 0
+	movd		%edx,			%xmm3
+	andpd		%xmm0,			%xmm1	// (big input) ? input & 0xfff : 0
+	movsd		TWOp52,			%xmm2	// 0x1.0p52
+	psrlq		%xmm3,			%xmm0	// (big input) ? input >> 12 : input
+	orpd		%xmm2,			%xmm1	// 0x1.0p52 + ((big input) ? input & 0xfff : input)
+	orpd		%xmm1,			%xmm0	// 0x1.0p52 + ((big input) ? (input >> 12 | input & 0xfff) : input)
+	subsd		%xmm2,			%xmm0	// (double)((big input) ? (input >> 12 | input & 0xfff) : input)
+	cvtsd2ss	%xmm0,			%xmm0	// (float)((big input) ? (input >> 12 | input & 0xfff) : input)
+	pslld		$23,			%xmm3
+	paddd		%xmm3,			%xmm0	// (float)input
+	movd		%xmm0,			4(%esp)
+	flds		4(%esp)
+	ret
+END_COMPILERRT_FUNCTION(__floatundisf)
+
+#endif // __i386__

--- a/i387/floatundixf.S
+++ b/i387/floatundixf.S
@@ -1,0 +1,38 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// long double __floatundixf(du_int a);16
+
+#ifdef __i386__
+
+#ifndef __ELF__
+.const
+#endif
+.balign 4
+twop52: .quad 0x4330000000000000
+twop84_plus_twop52_neg:
+		.quad 0xc530000000100000
+twop84: .quad 0x4530000000000000
+
+#define REL_ADDR(_a)	(_a)-0b(%eax)
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__floatundixf)
+	calll	0f
+0:	popl	%eax
+	movss	8(%esp),			%xmm0	// hi 32 bits of input
+	movss	4(%esp),			%xmm1	// lo 32 bits of input
+	orpd	REL_ADDR(twop84),	%xmm0	// 2^84 + hi (as a double)
+	orpd	REL_ADDR(twop52),	%xmm1	// 2^52 + lo (as a double)
+	addsd	REL_ADDR(twop84_plus_twop52_neg),	%xmm0	// hi - 2^52 (no rounding occurs)
+	movsd	%xmm1,				4(%esp)
+	fldl	4(%esp)
+	movsd	%xmm0,				4(%esp)
+	faddl	4(%esp)
+	ret
+END_COMPILERRT_FUNCTION(__floatundixf)
+
+#endif // __i386__

--- a/i387/int_endianness.h
+++ b/i387/int_endianness.h
@@ -1,0 +1,111 @@
+/* ===-- int_endianness.h - configuration header for compiler-rt ------------===
+ *
+ *		       The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file is a configuration header for compiler-rt.
+ * This file is not part of the interface of this library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef INT_ENDIANNESS_H
+#define INT_ENDIANNESS_H
+
+#if defined(__SVR4) && defined(__sun)
+#include <sys/byteorder.h>
+
+#if defined(_BIG_ENDIAN)
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN    1
+#elif defined(_LITTLE_ENDIAN)
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN    0
+#else /* !_LITTLE_ENDIAN */
+#error "unknown endianness"
+#endif /* !_LITTLE_ENDIAN */
+
+#endif /* Solaris and AuroraUX. */
+
+/* .. */
+
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__minix)
+#include <sys/endian.h>
+
+#if _BYTE_ORDER == _BIG_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN    1
+#elif _BYTE_ORDER == _LITTLE_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN    0
+#endif /* _BYTE_ORDER */
+
+#endif /* *BSD */
+
+#if defined(__OpenBSD__) || defined(__Bitrig__)
+#include <machine/endian.h>
+
+#if _BYTE_ORDER == _BIG_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN    1
+#elif _BYTE_ORDER == _LITTLE_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN    0
+#endif /* _BYTE_ORDER */
+
+#endif /* OpenBSD and Bitrig. */
+
+/* .. */
+
+/* Mac OSX has __BIG_ENDIAN__ or __LITTLE_ENDIAN__ automatically set by the compiler (at least with GCC) */
+#if defined(__APPLE__) || defined(__ellcc__ )
+
+#ifdef __BIG_ENDIAN__
+#if __BIG_ENDIAN__
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN    1
+#endif
+#endif /* __BIG_ENDIAN__ */
+
+#ifdef __LITTLE_ENDIAN__
+#if __LITTLE_ENDIAN__
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN    0
+#endif
+#endif /* __LITTLE_ENDIAN__ */
+
+#endif /* Mac OSX */
+
+/* .. */
+
+#if defined(__linux__)
+#include <endian.h>
+
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 0
+#define _YUGA_BIG_ENDIAN    1
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN    0
+#endif /* __BYTE_ORDER */
+
+#endif /* GNU/Linux */
+
+#if defined(_WIN32)
+
+#define _YUGA_LITTLE_ENDIAN 1
+#define _YUGA_BIG_ENDIAN    0
+
+#endif /* Windows */
+
+/* . */
+
+#if !defined(_YUGA_LITTLE_ENDIAN) || !defined(_YUGA_BIG_ENDIAN)
+#error Unable to determine endian
+#endif /* Check we found an endianness correctly. */
+
+#endif /* INT_ENDIANNESS_H */

--- a/i387/int_lib.h
+++ b/i387/int_lib.h
@@ -1,0 +1,76 @@
+/* ===-- int_lib.h - configuration header for compiler-rt  -----------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file is a configuration header for compiler-rt.
+ * This file is not part of the interface of this library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef INT_LIB_H
+#define INT_LIB_H
+
+/* Assumption: Signed integral is 2's complement. */
+/* Assumption: Right shift of signed negative is arithmetic shift. */
+/* Assumption: Endianness is little or big (not mixed). */
+
+/* ABI macro definitions */
+
+/*
+ * TODO define this appropriately for targets that require explicit export
+ * declarations (i.e. Windows)
+ */
+#define COMPILER_RT_EXPORT
+
+#if __ARM_EABI__
+# define ARM_EABI_FNALIAS(aeabi_name, name)         \
+  void __aeabi_##aeabi_name() __attribute__((alias("__" #name)));
+# define COMPILER_RT_ABI COMPILER_RT_EXPORT __attribute__((pcs("aapcs")))
+#else
+# define ARM_EABI_FNALIAS(aeabi_name, name)
+# define COMPILER_RT_ABI COMPILER_RT_EXPORT
+#endif
+
+#if defined(__NetBSD__) && (defined(_KERNEL) || defined(_STANDALONE))
+/*
+ * Kernel and boot environment can't use normal headers,
+ * so use the equivalent system headers.
+ */
+#  include <machine/limits.h>
+#  include <sys/stdint.h>
+#  include <sys/types.h>
+#else
+/* Include the standard compiler builtin headers we use functionality from. */
+#  include <limits.h>
+#  include <stdint.h>
+#  include <stdbool.h>
+#  include <float.h>
+#endif
+
+/* Include the commonly used internal type definitions. */
+#include "int_types.h"
+
+/* Include internal utility function declarations. */
+#include "int_util.h"
+
+COMPILER_RT_ABI si_int __paritysi2(si_int a);
+COMPILER_RT_ABI si_int __paritydi2(di_int a);
+
+COMPILER_RT_ABI di_int __divdi3(di_int a, di_int b);
+COMPILER_RT_ABI si_int __divsi3(si_int a, si_int b);
+COMPILER_RT_ABI su_int __udivsi3(su_int n, su_int d);
+
+COMPILER_RT_ABI su_int __udivmodsi4(su_int a, su_int b, su_int* rem);
+COMPILER_RT_ABI du_int __udivmoddi4(du_int a, du_int b, du_int* rem);
+#ifdef CRT_HAS_128BIT
+COMPILER_RT_ABI si_int __clzti2(ti_int a);
+COMPILER_RT_ABI tu_int __udivmodti4(tu_int a, tu_int b, tu_int* rem);
+#endif
+
+#endif /* INT_LIB_H */

--- a/i387/int_types.h
+++ b/i387/int_types.h
@@ -1,0 +1,143 @@
+/* ===-- int_lib.h - configuration header for compiler-rt  -----------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file is not part of the interface of this library.
+ *
+ * This file defines various standard types, most importantly a number of unions
+ * used to access parts of larger types.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef INT_TYPES_H
+#define INT_TYPES_H
+
+#include "int_endianness.h"
+
+typedef      int si_int;
+typedef unsigned su_int;
+
+typedef          long long di_int;
+typedef unsigned long long du_int;
+
+typedef union
+{
+    di_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        su_int low;
+        si_int high;
+#else
+        si_int high;
+        su_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    }s;
+} dwords;
+
+typedef union
+{
+    du_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        su_int low;
+        su_int high;
+#else
+        su_int high;
+        su_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    }s;
+} udwords;
+
+#if __LP64__
+#define CRT_HAS_128BIT
+#endif
+
+#ifdef CRT_HAS_128BIT
+typedef int      ti_int __attribute__ ((mode (TI)));
+typedef unsigned tu_int __attribute__ ((mode (TI)));
+
+typedef union
+{
+    ti_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        du_int low;
+        di_int high;
+#else
+        di_int high;
+        du_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    }s;
+} twords;
+
+typedef union
+{
+    tu_int all;
+    struct
+    {
+#if _YUGA_LITTLE_ENDIAN
+        du_int low;
+        du_int high;
+#else
+        du_int high;
+        du_int low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+    }s;
+} utwords;
+
+static inline ti_int make_ti(di_int h, di_int l) {
+    twords r;
+    r.s.high = h;
+    r.s.low = l;
+    return r.all;
+}
+
+static inline tu_int make_tu(du_int h, du_int l) {
+    utwords r;
+    r.s.high = h;
+    r.s.low = l;
+    return r.all;
+}
+
+#endif /* CRT_HAS_128BIT */
+
+typedef union
+{
+    su_int u;
+    float f;
+} float_bits;
+
+typedef union
+{
+    udwords u;
+    double  f;
+} double_bits;
+
+typedef struct
+{
+#if _YUGA_LITTLE_ENDIAN
+    udwords low;
+    udwords high;
+#else
+    udwords high;
+    udwords low;
+#endif /* _YUGA_LITTLE_ENDIAN */
+} uqwords;
+
+typedef union
+{
+    uqwords     u;
+    long double f;
+} long_double_bits;
+
+#endif /* INT_TYPES_H */
+

--- a/i387/int_util.h
+++ b/i387/int_util.h
@@ -1,0 +1,29 @@
+/* ===-- int_util.h - internal utility functions ----------------------------===
+ *
+ *                     The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===-----------------------------------------------------------------------===
+ *
+ * This file is not part of the interface of this library.
+ *
+ * This file defines non-inline utilities which are available for use in the
+ * library. The function definitions themselves are all contained in int_util.c
+ * which will always be compiled into any compiler-rt library.
+ *
+ * ===-----------------------------------------------------------------------===
+ */
+
+#ifndef INT_UTIL_H
+#define INT_UTIL_H
+
+/** \brief Trigger a program abort (or panic for kernel code). */
+#define compilerrt_abort() compilerrt_abort_impl(__FILE__, __LINE__, \
+                                                 __func__)
+
+void compilerrt_abort_impl(const char *file, int line,
+                           const char *function) __attribute__((noreturn));
+
+#endif /* INT_UTIL_H */

--- a/i387/lshrdi3.S
+++ b/i387/lshrdi3.S
@@ -1,0 +1,59 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// di_int __lshrdi3(di_int input, int count);
+
+// This routine has some extra memory traffic, loading the 64-bit input via two
+// 32-bit loads, then immediately storing it back to the stack via a single 64-bit
+// store.  This is to avoid a write-small, read-large stall.
+// However, if callers of this routine can be safely assumed to store the argument
+// via a 64-bt store, this is unnecessary memory traffic, and should be avoided.
+// It can be turned off by defining the TRUST_CALLERS_USE_64_BIT_STORES macro.
+
+#ifdef __i386__
+#ifdef __SSE2__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__lshrdi3)
+	movd	  12(%esp),		%xmm2	// Load count
+#ifndef TRUST_CALLERS_USE_64_BIT_STORES
+	movd	   4(%esp),		%xmm0
+	movd	   8(%esp),		%xmm1
+	punpckldq	%xmm1,		%xmm0	// Load input
+#else
+	movq	   4(%esp),		%xmm0	// Load input
+#endif
+	psrlq		%xmm2,		%xmm0	// shift input by count
+	movd		%xmm0,		%eax
+	psrlq		$32,		%xmm0
+	movd		%xmm0,		%edx
+	ret
+END_COMPILERRT_FUNCTION(__lshrdi3)
+
+#else // Use GPRs instead of SSE2 instructions, if they aren't available.
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__lshrdi3)
+	movl	  12(%esp),		%ecx	// Load count
+	movl	   8(%esp),		%edx	// Load high
+	movl	   4(%esp),		%eax	// Load low
+	
+	testl		$0x20,		%ecx	// If count >= 32
+	jnz			1f					//    goto 1
+
+	shrdl		%cl, %edx,	%eax	// right shift low by count
+	shrl		%cl,		%edx	// right shift high by count
+	ret
+	
+1:	movl		%edx,		%eax	// Move high to low
+	xorl		%edx,		%edx	// clear high
+	shrl		%cl,		%eax	// shift low by count - 32
+	ret
+END_COMPILERRT_FUNCTION(__lshrdi3)
+
+#endif // __SSE2__
+#endif // __i386__

--- a/i387/moddi3.S
+++ b/i387/moddi3.S
@@ -1,0 +1,166 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// di_int __moddi3(di_int a, di_int b);
+
+// result = remainder of a / b.
+// both inputs and the output are 64-bit signed integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+
+// Stephen Canon, December 2008
+
+#ifdef __i386__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__moddi3)
+
+/* This is currently implemented by wrapping the unsigned modulus up in an absolute
+   value.  This could certainly be improved upon. */
+
+	pushl		%esi
+	movl	 20(%esp),			%edx	// high word of b
+	movl	 16(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (b < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (b < 0) ? not(b) : b
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(b)
+	movl		%edx,		 20(%esp)
+	movl		%eax,		 16(%esp)	// store abs(b) back to stack
+	
+	movl	 12(%esp),			%edx	// high word of b
+	movl	  8(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (a < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (a < 0) ? not(a) : a
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(a)
+	movl		%edx,		 12(%esp)
+	movl		%eax,		  8(%esp)	// store abs(a) back to stack
+	movl		%ecx,			%esi	// set aside sign of a
+
+	pushl		%ebx
+	movl	 24(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+	
+	/* High word of b is known to be non-zero on this branch */
+	
+	movl	 20(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+	
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 16(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	 12(%esp),			%eax	// to [2] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			2f						
+		
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	
+	jnc			1f						// if positive, this is the result.
+	addl	 24(%esp),			%ebx	// otherwise
+	adcl	 28(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+1:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+	
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	retl								// Return
+
+2:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	 
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+
+	jnc			3f						// if positive, this is the result.
+	addl	 24(%esp),			%ebx	// otherwise
+	adcl	 28(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+3:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+	
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	retl								// Return
+	
+9:	/* High word of b is zero on this branch */
+
+	movl	 16(%esp),			%eax	// Find qhi and rhi such that
+	movl	 20(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	 12(%esp),			%eax	// Find rlo such that
+	divl		%ecx					//
+	movl		%edx,			%eax	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+	popl		%ebx					//
+	xorl		%edx,			%edx	// and return 0:rlo
+
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%esi
+	retl								// Return
+END_COMPILERRT_FUNCTION(__moddi3)
+
+#endif // __i386__

--- a/i387/muldi3.S
+++ b/i387/muldi3.S
@@ -1,0 +1,30 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// di_int __muldi3(di_int a, di_int b);
+
+#ifdef __i386__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__muldi3)
+	pushl	%ebx
+	movl  16(%esp),		%eax	// b.lo
+	movl  12(%esp),		%ecx	// a.hi
+	imull	%eax,		%ecx	// b.lo * a.hi
+	
+	movl   8(%esp),		%edx	// a.lo
+	movl  20(%esp),		%ebx	// b.hi
+	imull	%edx,		%ebx	// a.lo * b.hi
+	
+	mull	%edx				// EDX:EAX = a.lo * b.lo
+	addl	%ecx,		%ebx	// EBX = (a.lo*b.hi + a.hi*b.lo)
+	addl	%ebx,		%edx
+	
+	popl	%ebx
+	retl
+END_COMPILERRT_FUNCTION(__muldi3)
+
+#endif // __i386__

--- a/i387/udivdi3.S
+++ b/i387/udivdi3.S
@@ -1,0 +1,115 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// du_int __udivdi3(du_int a, du_int b);
+
+// result = a / b.
+// both inputs and the output are 64-bit unsigned integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+// Stephen Canon, December 2008
+
+#ifdef __i386__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__udivdi3)
+
+	pushl		%ebx
+	movl	 20(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+	
+	/* High word of b is known to be non-zero on this branch */
+	
+	movl	 16(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+	
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 12(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	  8(%esp),			%eax	// to [1] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			1f						
+		
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+	popl		%edi
+	popl		%ebx
+	retl
+
+
+1:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	 
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+	popl		%edi
+	popl		%ebx
+	retl
+
+	
+9:	/* High word of b is zero on this branch */
+
+	movl	 12(%esp),			%eax	// Find qhi and rhi such that
+	movl	 16(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	  8(%esp),			%eax	// Find qlo such that
+	divl		%ecx					//
+	movl		%ebx,			%edx	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+	popl		%ebx					//
+	retl								// and return qhi:qlo
+END_COMPILERRT_FUNCTION(__udivdi3)
+
+#endif // __i386__

--- a/i387/umoddi3.S
+++ b/i387/umoddi3.S
@@ -1,0 +1,126 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+#include "assembly.h"
+
+// du_int __umoddi3(du_int a, du_int b);
+
+// result = remainder of a / b.
+// both inputs and the output are 64-bit unsigned integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+
+// Stephen Canon, December 2008
+
+#ifdef __i386__
+
+.text
+.balign 4
+DEFINE_COMPILERRT_FUNCTION(__umoddi3)
+
+	pushl		%ebx
+	movl	 20(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+	
+	/* High word of b is known to be non-zero on this branch */
+	
+	movl	 16(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+	
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 12(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	  8(%esp),			%eax	// to [2] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			2f						
+		
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	
+	jnc			1f						// if positive, this is the result.
+	addl	 20(%esp),			%ebx	// otherwise
+	adcl	 24(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+1:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+	
+	popl		%edi
+	popl		%ebx
+	retl
+
+
+2:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+	 
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+
+	jnc			3f						// if positive, this is the result.
+	addl	 20(%esp),			%ebx	// otherwise
+	adcl	 24(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+3:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+	
+	popl		%edi
+	popl		%ebx
+	retl
+
+
+	
+9:	/* High word of b is zero on this branch */
+
+	movl	 12(%esp),			%eax	// Find qhi and rhi such that
+	movl	 16(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	  8(%esp),			%eax	// Find rlo such that
+	divl		%ecx					//
+	movl		%edx,			%eax	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+	popl		%ebx					//
+	xorl		%edx,			%edx	// and return 0:rlo
+	retl								// 
+END_COMPILERRT_FUNCTION(__umoddi3)
+
+#endif // __i386__


### PR DESCRIPTION
....

On i386 platforms, modern compilers are emitting call-outs to 64-bit integer
arithmetic. This patch adds support for these functions. Implementations are
taken from LLVM's compiler-rt library, which appears to have a compatible
license with openlibm. Appropriate license information has been added to
LICENSE.md to reflect this merge.