### PR TITLE
Fix build on ARM and add Travis tests

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eux
+
+case "$TARGET" in
+host)
+	uname -a
+	export LOADER=
+	make ;;
+arm32)
+	sudo bash -c 'echo >> /etc/apt/sources.list "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted universe"'
+	sudo apt-get update
+	sudo apt-get -y install gcc-4.7-arm-linux-gnueabihf qemu binfmt-support
+	make CC="arm-linux-gnueabihf-gcc-4.7"
+	export LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib
+	#export LOADER=/usr/arm-linux-gnueabihf/lib/ld-linux-armhf.so.3
+	export LOADER="echo TESTS DISABLED ON ARM"
+	;;
+*)
+	echo 'Unknown TARGET!'
+	exit 1
+	;;
+esac
+
+$LOADER ./test/test-double
+$LOADER ./test/test-float

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+script: ./.travis.sh
+env:
+- TARGET=host
+- TARGET=arm32

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ clean:
 	@for dir in $(SUBDIRS) .; do \
 		rm -fr $$dir/*.o $$dir/*.a $$dir/*.$(SHLIB_EXT)*; \
 	done
+	@rm -f test/test-double test/test-float
 
 distclean:
 	-rm -f $(OBJS) *.a *.$(SHLIB_EXT) libopenlibm.*

--- a/src/Make.files
+++ b/src/Make.files
@@ -10,7 +10,7 @@ $(CUR_SRCS) = common.c \
 	e_sinh.c e_sinhf.c e_sqrt.c e_sqrtf.c \
 	k_cos.c k_exp.c k_expf.c k_rem_pio2.c k_sin.c k_tan.c \
 	k_cosf.c k_sinf.c k_tanf.c \
-	s_asinh.c s_asinhf.c s_atan.c s_atanf.c s_carg.c s_cargf.c s_cargl.c \
+	s_asinh.c s_asinhf.c s_atan.c s_atanf.c s_carg.c s_cargf.c \
 	s_cbrt.c s_cbrtf.c s_ceil.c s_ceilf.c \
 	s_copysign.c s_copysignf.c s_cos.c s_cosf.c \
 	s_csqrt.c s_csqrtf.c s_erf.c s_erff.c \
@@ -30,7 +30,7 @@ $(CUR_SRCS) = common.c \
 	s_scalbln.c s_scalbn.c s_scalbnf.c s_signbit.c \
 	s_signgam.c s_significand.c s_significandf.c s_sin.c s_sincos.c \
 	s_sinf.c s_sincosf.c s_tan.c s_tanf.c s_tanh.c s_tanhf.c s_tgammaf.c \
-	s_trunc.c s_truncf.c s_cpow.c  s_cpowf.c s_cpowl.c \
+	s_trunc.c s_truncf.c s_cpow.c  s_cpowf.c \
 	w_cabs.c w_cabsf.c w_drem.c w_dremf.c
 
 ifneq ($(OS), WINNT)
@@ -48,22 +48,24 @@ $(CUR_SRCS) +=	e_acosl.c e_asinl.c e_atan2l.c e_fmodl.c \
 	s_atanl.c s_ceill.c s_cosl.c s_cprojl.c \
 	s_csqrtl.c s_floorl.c s_fmal.c \
 	s_frexpl.c s_logbl.c s_nexttoward.c \
-	s_remquol.c \
+	s_remquol.c s_cpowl.c s_cargl.c \
 	s_sinl.c s_sincosl.c s_tanl.c s_truncl.c w_cabsl.c \
-	s_nextafterl.c s_rintl.c s_scalbnl.c polevll.c
+	s_nextafterl.c s_rintl.c s_scalbnl.c polevll.c \
+	s_casinl.c s_ctanl.c \
+	s_cimagl.c s_conjl.c s_creall.c s_cacoshl.c s_catanhl.c s_casinhl.c \
+	s_catanl.c s_csinl.c s_cacosl.c s_cexpl.c s_csinhl.c s_ccoshl.c \
+	s_clogl.c s_ctanhl.c s_ccosl.c
 #	s_cbrtl.c
 endif
 
 # C99 complex functions
 $(CUR_SRCS) +=	s_ccosh.c s_ccoshf.c s_cexp.c s_cexpf.c \
-	s_cimag.c s_cimagf.c s_cimagl.c \
-	s_conj.c s_conjf.c s_conjl.c \
-	s_cproj.c s_cprojf.c s_creal.c s_crealf.c s_creall.c \
+	s_cimag.c s_cimagf.c \
+	s_conj.c s_conjf.c \
+	s_cproj.c s_cprojf.c s_creal.c s_crealf.c \
 	s_csinh.c s_csinhf.c s_ctanh.c s_ctanhf.c \
         s_cacos.c s_cacosf.c \
-        s_cacosh.c s_cacoshf.c s_cacoshl.c s_cacosl.c \
-        s_casin.c s_casinf.c s_casinh.c s_casinhf.c s_casinhl.c \
-        s_casinl.c s_catan.c s_catanf.c s_catanh.c s_catanhf.c s_catanhl.c \
-        s_catanl.c s_ccoshl.c s_ccosl.c s_cexpl.c \
-        s_clog.c s_clogf.c s_clogl.c \
-        s_csinhl.c s_csinl.c s_ctanhl.c s_ctanl.c
+        s_cacosh.c s_cacoshf.c \
+        s_casin.c s_casinf.c s_casinh.c s_casinhf.c \
+        s_catan.c s_catanf.c s_catanh.c s_catanhf.c \
+        s_clog.c s_clogf.c


### PR DESCRIPTION
Recent changes had broken the build on ARM by adding more long double functions. These should be skipped on ARM, where double = long double.

This commit also adds Travis CI tests, which can be run automatically on every push to github. To do that, go to https://travis-ci.org/ and enable tests for the repository (it's free). Ideally, do this before merging (it will only run the tests for commits made after enabling it).

Here's the output from my fork (which has tests enabled): https://travis-ci.org/talex5/openlibm/builds/45933733

It does two builds on each commit, one on x86 and one cross-compiling to arm (which would detect the bug fixed above). On x86, it also runs the unit-tests. As the unit-tests currently fail on ARM I have disabled them, but if you set LOADER to `ld-linux-armhf.so.3` in the `.travis.sh` file (it's commented out at the moment) then it will run them too, if you want to debug it.