### PR TITLE
Make openlibm less dependent on the host, but still add knobs to build against it

### DIFF
--- a/amd64/fenv.c
+++ b/amd64/fenv.c
@@ -32,7 +32,7 @@
 #ifdef _WIN32
 #define __fenv_static
 #endif
-#include "fenv.h"
+#include "openlibm_fenv.h"
 
 #ifdef __GNUC_GNU_INLINE__
 #error "This file must be compiled with C99 'inline' semantics"

--- a/amd64/fenv.c
+++ b/amd64/fenv.c
@@ -32,7 +32,7 @@
 #ifdef _WIN32
 #define __fenv_static
 #endif
-#include "openlibm_fenv.h"
+#include <openlibm_fenv.h>
 
 #ifdef __GNUC_GNU_INLINE__
 #error "This file must be compiled with C99 'inline' semantics"

--- a/amd64/fenv.h
+++ b/amd64/fenv.h
@@ -29,8 +29,10 @@
 #ifndef	_FENV_H_
 #define	_FENV_H_
 
-#include "include/cdefs-compat.h"
-#include "include/types-compat.h"
+#include "cdefs-compat.h"
+#include "types-compat.h"
+
+#include "math_private.h"
 
 #ifndef	__fenv_static
 #define	__fenv_static	static

--- a/arm/fenv.c
+++ b/arm/fenv.c
@@ -27,7 +27,7 @@
  */
 
 #define	__fenv_static
-#include "fenv.h"
+#include <openlibm_fenv.h>
 
 #ifdef __GNUC_GNU_INLINE__
 #error "This file must be compiled with C99 'inline' semantics"

--- a/i387/fenv.c
+++ b/i387/fenv.c
@@ -32,7 +32,7 @@
 #include <i387/bsd_npx.h>
 
 #define	__fenv_static
-#include "fenv.h"
+#include <openlibm_fenv.h>
 
 #ifdef __GNUC_GNU_INLINE__
 #error "This file must be compiled with C99 'inline' semantics"

--- a/include/fenv.h
+++ b/include/fenv.h
@@ -1,9 +1,0 @@
-#ifdef __arm__
-#include "../arm/fenv.h"
-#else
-#ifdef __LP64
-#include "../amd64/fenv.h"
-#else
-#include "../i387/fenv.h"
-#endif
-#endif

--- a/ld128/e_acoshl.c
+++ b/ld128/e_acoshl.c
@@ -24,7 +24,7 @@
  *	acoshl(NaN) is NaN without signal.
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_atanhl.c
+++ b/ld128/e_atanhl.c
@@ -28,7 +28,7 @@
  *
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_coshl.c
+++ b/ld128/e_coshl.c
@@ -46,7 +46,7 @@
  *      only coshl(0)=1 is exact for finite x.
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_expl.c
+++ b/ld128/e_expl.c
@@ -73,7 +73,7 @@
 /*	Exponential function	*/
 
 #include <float.h>
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_fmodl.c
+++ b/ld128/e_fmodl.c
@@ -16,7 +16,7 @@
  * Method: shift and subtract
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_hypotl.c
+++ b/ld128/e_hypotl.c
@@ -42,7 +42,7 @@
  * 	than 1 ulps (units in the last place)
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_lgammal_r.c
+++ b/ld128/e_lgammal_r.c
@@ -69,7 +69,7 @@
  *
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_log10l.c
+++ b/ld128/e_log10l.c
@@ -59,7 +59,7 @@
  *
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_log2l.c
+++ b/ld128/e_log2l.c
@@ -58,7 +58,7 @@
  *
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_logl.c
+++ b/ld128/e_logl.c
@@ -60,7 +60,7 @@
  *
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_powl.c
+++ b/ld128/e_powl.c
@@ -59,7 +59,7 @@
  *
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_rem_pio2l.h
+++ b/ld128/e_rem_pio2l.h
@@ -23,8 +23,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 #include "fpmath.h"
 

--- a/ld128/e_sinhl.c
+++ b/ld128/e_sinhl.c
@@ -44,7 +44,7 @@
  *      only sinhl(0)=0 is exact for finite x.
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/e_tgammal.c
+++ b/ld128/e_tgammal.c
@@ -16,7 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/k_tanl.c
+++ b/ld128/k_tanl.c
@@ -18,7 +18,8 @@
  * ld128 version of k_tan.c.  See ../src/k_tan.c for most comments.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 /*

--- a/ld128/s_asinhl.c
+++ b/ld128/s_asinhl.c
@@ -21,7 +21,7 @@
  *                := signl(x)*log1pl(|x| + x^2/(1 + sqrtl(1+x^2)))
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_ceill.c
+++ b/ld128/s_ceill.c
@@ -19,7 +19,7 @@
  *	Inexact flag raised if x not equal to ceil(x).
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_erfl.c
+++ b/ld128/s_erfl.c
@@ -91,7 +91,7 @@
  *		erfc/erf(NaN) is NaN
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_exp2l.c
+++ b/ld128/s_exp2l.c
@@ -28,10 +28,10 @@
 //__FBSDID("$FreeBSD: src/lib/msun/ld128/s_exp2l.c,v 1.3 2008/02/13 10:44:44 bde Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 #include <stdint.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 #define	TBLBITS	7

--- a/ld128/s_expm1l.c
+++ b/ld128/s_expm1l.c
@@ -54,7 +54,7 @@
  */
 
 #include <errno.h>
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_floorl.c
+++ b/ld128/s_floorl.c
@@ -19,7 +19,7 @@
  *	Inexact flag raised if x not equal to floor(x).
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_log1pl.c
+++ b/ld128/s_log1pl.c
@@ -54,7 +54,7 @@
  *    IEEE      -1, 8       100000      1.9e-34     4.3e-35
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_modfl.c
+++ b/ld128/s_modfl.c
@@ -20,7 +20,7 @@
  *	No exception.
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_nanl.c
+++ b/ld128/s_nanl.c
@@ -26,7 +26,7 @@
  * $FreeBSD: src/lib/msun/ld128/s_nanl.c,v 1.3 2008/03/02 20:16:55 das Exp $
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
 
 #include "fpmath.h"
 #include "math_private.h"

--- a/ld128/s_nextafterl.c
+++ b/ld128/s_nextafterl.c
@@ -17,7 +17,7 @@
  *   Special cases:
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_nexttoward.c
+++ b/ld128/s_nexttoward.c
@@ -17,8 +17,8 @@
  *   Special cases:
  */
 
-#include <math.h>
 #include <float.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_nexttowardf.c
+++ b/ld128/s_nexttowardf.c
@@ -10,7 +10,7 @@
  * ====================================================
  */
 
-#include <math.h>
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/ld128/s_remquol.c
+++ b/ld128/s_remquol.c
@@ -14,7 +14,7 @@
 #include <machine/ieee.h>
 
 #include <float.h>
-#include <math.h>
+#include <openlibm.h>
 #include <stdint.h>
 
 #include "math_private.h"

--- a/ld128/s_tanhl.c
+++ b/ld128/s_tanhl.c
@@ -50,7 +50,8 @@
  *      only tanhl(0)=0 is exact for finite argument.
  */
 
-#include "math.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const long double one = 1.0, two = 2.0, tiny = 1.0e-4900L;

--- a/ld128/s_truncl.c
+++ b/ld128/s_truncl.c
@@ -24,7 +24,7 @@
 #include <machine/ieee.h>
 
 #include <float.h>
-#include <math.h>
+#include <openlibm.h>
 #include <stdint.h>
 
 #include "math_private.h"

--- a/ld80/e_coshl.c
+++ b/ld80/e_coshl.c
@@ -31,7 +31,8 @@
  *	only coshl(0)=1 is exact for finite x.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const long double one = 1.0, half=0.5, huge = 1.0e4900L;

--- a/ld80/e_rem_pio2l.h
+++ b/ld80/e_rem_pio2l.h
@@ -23,10 +23,9 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
-#include "openlibm.h"
 
 #define	BIAS	(LDBL_MAX_EXP - 1)
 

--- a/ld80/k_tanl.c
+++ b/ld80/k_tanl.c
@@ -18,7 +18,8 @@
  * ld80 version of k_tan.c.  See ../src/k_tan.c for most comments.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 /*

--- a/ld80/s_exp2l.c
+++ b/ld80/s_exp2l.c
@@ -32,8 +32,8 @@
 
 #include "amd64/bsd_ieeefp.h"
 
-#include "openlibm.h"
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 #define	TBLBITS	7

--- a/ld80/s_nanl.c
+++ b/ld80/s_nanl.c
@@ -26,9 +26,8 @@
  * $FreeBSD: src/lib/msun/ld80/s_nanl.c,v 1.2 2007/12/18 23:46:31 das Exp $
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT long double

--- a/ld80/s_truncl.c
+++ b/ld80/s_truncl.c
@@ -24,7 +24,7 @@
 //#include <machine/ieee.h>
 
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
 #include <stdint.h>
 
 #include "math_private.h"

--- a/src/e_acos.c
+++ b/src/e_acos.c
@@ -39,8 +39,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/e_acosf.c
+++ b/src/e_acosf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_acosf.c,v 1.11 2008/08/03 17:39:54 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/e_acosh.c
+++ b/src/e_acosh.c
@@ -29,7 +29,8 @@
  *	acosh(NaN) is NaN without signal.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/e_acoshf.c
+++ b/src/e_acoshf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_acoshf.c,v 1.8 2008/02/22 02:30:34 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/e_acosl.c
+++ b/src/e_acosl.c
@@ -21,9 +21,9 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "invtrig.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 static const long double

--- a/src/e_asin.c
+++ b/src/e_asin.c
@@ -45,8 +45,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/e_asinf.c
+++ b/src/e_asinf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_asinf.c,v 1.13 2008/08/08 00:21:27 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/e_asinl.c
+++ b/src/e_asinl.c
@@ -21,9 +21,9 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "invtrig.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 static const long double

--- a/src/e_atan2.c
+++ b/src/e_atan2.c
@@ -43,8 +43,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static volatile double

--- a/src/e_atan2f.c
+++ b/src/e_atan2f.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_atan2f.c,v 1.12 2008/08/03 17:39:54 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static volatile float

--- a/src/e_atan2l.c
+++ b/src/e_atan2l.c
@@ -22,9 +22,9 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "invtrig.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 static volatile long double

--- a/src/e_atanh.c
+++ b/src/e_atanh.c
@@ -33,7 +33,8 @@
  *
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double one = 1.0, huge = 1e300;

--- a/src/e_atanhf.c
+++ b/src/e_atanhf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_atanhf.c,v 1.7 2008/02/22 02:30:34 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float one = 1.0, huge = 1e30;

--- a/src/e_cosh.c
+++ b/src/e_cosh.c
@@ -35,7 +35,8 @@
  *	only cosh(0)=1 is exact for finite x.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double one = 1.0, half=0.5, huge = 1.0e300;

--- a/src/e_coshf.c
+++ b/src/e_coshf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_coshf.c,v 1.9 2011/10/21 06:28:47 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float one = 1.0, half=0.5, huge = 1.0e30;

--- a/src/e_exp.c
+++ b/src/e_exp.c
@@ -77,8 +77,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/e_expf.c
+++ b/src/e_expf.c
@@ -17,8 +17,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_expf.c,v 1.16 2011/10/21 06:26:38 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const float

--- a/src/e_fmod.c
+++ b/src/e_fmod.c
@@ -20,7 +20,8 @@
  * Method: shift and subtract
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double one = 1.0, Zero[] = {0.0, -0.0,};

--- a/src/e_fmodf.c
+++ b/src/e_fmodf.c
@@ -22,7 +22,8 @@
  * Method: shift and subtract
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float one = 1.0, Zero[] = {0.0, -0.0,};

--- a/src/e_fmodl.c
+++ b/src/e_fmodl.c
@@ -14,10 +14,11 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_fmodl.c,v 1.2 2008/07/31 20:09:47 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 #include <stdint.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
+
 #include "math_private.h"
 
 #define	BIAS (LDBL_MAX_EXP - 1)

--- a/src/e_gamma.c
+++ b/src/e_gamma.c
@@ -21,7 +21,8 @@
  * Method: call __ieee754_gamma_r
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 extern int signgam;

--- a/src/e_gamma_r.c
+++ b/src/e_gamma_r.c
@@ -22,7 +22,8 @@
  * Method: See __ieee754_lgamma_r
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/e_gammaf.c
+++ b/src/e_gammaf.c
@@ -22,7 +22,8 @@
  * Method: call __ieee754_gammaf_r
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 extern int signgam;

--- a/src/e_gammaf_r.c
+++ b/src/e_gammaf_r.c
@@ -23,7 +23,8 @@
  * Method: See __ieee754_lgammaf_r
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/e_hypot.c
+++ b/src/e_hypot.c
@@ -47,8 +47,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/e_hypotf.c
+++ b/src/e_hypotf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_hypotf.c,v 1.14 2011/10/15 07:00:28 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/e_hypotl.c
+++ b/src/e_hypotl.c
@@ -16,9 +16,9 @@
 /* long double version of hypot().  See e_hypot.c for most comments. */
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 #define	GET_LDBL_MAN(h, l, v) do {	\

--- a/src/e_j0.c
+++ b/src/e_j0.c
@@ -61,7 +61,8 @@
  *	3. Special cases: y0(0)=-inf, y0(x<0)=NaN, y0(inf)=0.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static double pzero(double), qzero(double);

--- a/src/e_j0f.c
+++ b/src/e_j0f.c
@@ -18,7 +18,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_j0f.c,v 1.8 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static float pzerof(float), qzerof(float);

--- a/src/e_j1.c
+++ b/src/e_j1.c
@@ -61,7 +61,8 @@
  *	   by method mentioned above.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static double pone(double), qone(double);

--- a/src/e_j1f.c
+++ b/src/e_j1f.c
@@ -18,7 +18,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_j1f.c,v 1.8 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static float ponef(float), qonef(float);

--- a/src/e_jn.c
+++ b/src/e_jn.c
@@ -40,7 +40,8 @@
  *	
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/e_jnf.c
+++ b/src/e_jnf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_jnf.c,v 1.11 2010/11/13 10:54:10 uqs Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/e_lgamma.c
+++ b/src/e_lgamma.c
@@ -21,7 +21,8 @@
  * Method: call __ieee754_lgamma_r
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 extern int signgam;

--- a/src/e_lgamma_r.c
+++ b/src/e_lgamma_r.c
@@ -83,7 +83,8 @@
  *	
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/e_lgammaf.c
+++ b/src/e_lgammaf.c
@@ -22,7 +22,8 @@
  * Method: call __ieee754_lgammaf_r
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 extern int signgam;

--- a/src/e_lgammaf_r.c
+++ b/src/e_lgammaf_r.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_lgammaf_r.c,v 1.12 2011/10/15 07:00:28 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/e_lgammal.c
+++ b/src/e_lgammal.c
@@ -1,5 +1,7 @@
 #include "cdefs-compat.h"
-#include "openlibm.h"
+
+#include <openlibm.h>
+
 #include "math_private.h"
 
 extern int signgam;

--- a/src/e_log.c
+++ b/src/e_log.c
@@ -65,7 +65,8 @@
  * to produce the hexadecimal values shown.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/e_log10.c
+++ b/src/e_log10.c
@@ -22,7 +22,8 @@
  * in not-quite-routine extra precision.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 #include "k_log.h"
 

--- a/src/e_log10f.c
+++ b/src/e_log10f.c
@@ -16,7 +16,8 @@
  * Float version of e_log10.c.  See the latter for most comments.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 #include "k_logf.h"
 

--- a/src/e_log2.c
+++ b/src/e_log2.c
@@ -24,7 +24,8 @@
  * in not-quite-routine extra precision.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 #include "k_log.h"
 

--- a/src/e_log2f.c
+++ b/src/e_log2f.c
@@ -16,7 +16,8 @@
  * Float version of e_log2.c.  See the latter for most comments.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 #include "k_logf.h"
 

--- a/src/e_logf.c
+++ b/src/e_logf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_logf.c,v 1.11 2008/03/29 16:37:59 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/e_pow.c
+++ b/src/e_pow.c
@@ -57,7 +57,8 @@
  * to produce the hexadecimal values shown.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/e_powf.c
+++ b/src/e_powf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_powf.c,v 1.16 2011/10/21 06:26:07 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/e_rem_pio2.c
+++ b/src/e_rem_pio2.c
@@ -23,8 +23,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 /*

--- a/src/e_rem_pio2f.c
+++ b/src/e_rem_pio2f.c
@@ -25,8 +25,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 /*

--- a/src/e_remainder.c
+++ b/src/e_remainder.c
@@ -24,8 +24,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double zero = 0.0;

--- a/src/e_remainderf.c
+++ b/src/e_remainderf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_remainderf.c,v 1.8 2008/02/12 17:11:36 bde Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float zero = 0.0;

--- a/src/e_scalb.c
+++ b/src/e_scalb.c
@@ -20,7 +20,8 @@
  * should use scalbn() instead.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 #ifdef _SCALB_INT

--- a/src/e_scalbf.c
+++ b/src/e_scalbf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_scalbf.c,v 1.13 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 #ifdef _SCALB_INT

--- a/src/e_sinh.c
+++ b/src/e_sinh.c
@@ -32,7 +32,8 @@
  *	only sinh(0)=0 is exact for finite x.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double one = 1.0, shuge = 1.0e307;

--- a/src/e_sinhf.c
+++ b/src/e_sinhf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_sinhf.c,v 1.10 2011/10/21 06:28:47 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float one = 1.0, shuge = 1.0e37;

--- a/src/e_sqrt.c
+++ b/src/e_sqrt.c
@@ -85,8 +85,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static	const double	one	= 1.0, tiny=1.0e-300;

--- a/src/e_sqrtf.c
+++ b/src/e_sqrtf.c
@@ -13,7 +13,8 @@
  * ====================================================
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static	const float	one	= 1.0, tiny=1.0e-30;

--- a/src/e_sqrtl.c
+++ b/src/e_sqrtl.c
@@ -27,11 +27,11 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_sqrtl.c,v 1.1 2008/03/02 01:47:58 das Exp $");
 
-#include <fenv.h>
 #include <float.h>
 
 #include "fpmath.h"
 #include "openlibm.h"
+#include "openlibm_fenv.h"
 #include "math_private.h"
 
 /* Return (x + ulp) for normal positive x. Assumes no overflow. */

--- a/src/e_sqrtl.c
+++ b/src/e_sqrtl.c
@@ -28,10 +28,10 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/e_sqrtl.c,v 1.1 2008/03/02 01:47:58 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
+#include <openlibm_fenv.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
-#include "openlibm_fenv.h"
 #include "math_private.h"
 
 /* Return (x + ulp) for normal positive x. Assumes no overflow. */

--- a/src/k_cos.c
+++ b/src/k_cos.c
@@ -53,7 +53,8 @@
  *	   any extra precision in w.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/k_cosf.c
+++ b/src/k_cosf.c
@@ -19,7 +19,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/k_cosf.c,v 1.18 2009/06/03 08:16:34 ed Exp $");
 #endif
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 /* |cos(x) - c(x)| < 2**-34.1 (~[-5.37e-11, 5.295e-11]). */

--- a/src/k_exp.c
+++ b/src/k_exp.c
@@ -27,9 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/k_exp.c,v 1.1 2011/10/21 06:27:56 das Exp $");
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const u_int32_t k = 1799;		/* constant for reduction */

--- a/src/k_expf.c
+++ b/src/k_expf.c
@@ -27,9 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/k_expf.c,v 1.1 2011/10/21 06:27:56 das Exp $");
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const u_int32_t k = 235;			/* constant for reduction */

--- a/src/k_rem_pio2.c
+++ b/src/k_rem_pio2.c
@@ -130,8 +130,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const int init_jk[] = {3,4,4,6}; /* initial value for jk */

--- a/src/k_sin.c
+++ b/src/k_sin.c
@@ -44,7 +44,8 @@
  *		sin(x) = x + (S1*x + (x *(r-y/2)+y))
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/k_sinf.c
+++ b/src/k_sinf.c
@@ -19,7 +19,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/k_sinf.c,v 1.16 2009/06/03 08:16:34 ed Exp $");
 #endif
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 /* |sin(x)/x - s(x)| < 2**-37.5 (~[-4.89e-12, 4.824e-12]). */

--- a/src/k_tan.c
+++ b/src/k_tan.c
@@ -49,8 +49,10 @@
  *		       = 1 - 2*(tan(y) - (tan(y)^2)/(1+tan(y)))
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
+
 static const double xxx[] = {
 		 3.33333333333334091986e-01,	/* 3FD55555, 55555563 */
 		 1.33333333333201242699e-01,	/* 3FC11111, 1110FE7A */

--- a/src/k_tanf.c
+++ b/src/k_tanf.c
@@ -18,7 +18,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/k_tanf.c,v 1.23 2009/06/03 08:16:34 ed Exp $");
 #endif
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 /* |tan(x)/x - t(x)| < 2**-25.5 (~[-2e-08, 2e-08]). */

--- a/src/math_private.h
+++ b/src/math_private.h
@@ -17,10 +17,11 @@
 #ifndef _MATH_PRIVATE_H_
 #define	_MATH_PRIVATE_H_
 
+#include <openlibm_complex.h>
+
 #include "cdefs-compat.h"
 #include "types-compat.h"
 #include "fpmath.h"
-#include <complex.h>
 #include <stdint.h>
 #include "math_private_openbsd.h"
 

--- a/src/openlibm.h
+++ b/src/openlibm.h
@@ -17,8 +17,6 @@
 #ifndef OPENLIBM_H
 #define	OPENLIBM_H
 
-#include <openlibm_complex.h>
-
 #if (defined(_WIN32) || defined (_MSC_VER)) && !defined(__WIN32__)
     #define __WIN32__
 #endif
@@ -179,102 +177,6 @@ extern int signgam;
 #define	HUGE		MAXFLOAT
 #endif
 #endif /* __BSD_VISIBLE */
-
-//VBS
-//#ifdef _COMPLEX_H
-
-/*
- * C99 specifies that complex numbers have the same representation as
- * an array of two elements, where the first element is the real part
- * and the second element is the imaginary part.
- */
-typedef union {
-	float complex f;
-	float a[2];
-} float_complex;
-typedef union {
-	double complex f;
-	double a[2];
-} double_complex;
-typedef union {
-	long double complex f;
-	long double a[2];
-} long_double_complex;
-#define	REALPART(z)	((z).a[0])
-#define	IMAGPART(z)	((z).a[1])
-
-/*
- * Macros that can be used to construct complex values.
- *
- * The C99 standard intends x+I*y to be used for this, but x+I*y is
- * currently unusable in general since gcc introduces many overflow,
- * underflow, sign and efficiency bugs by rewriting I*y as
- * (0.0+I)*(y+0.0*I) and laboriously computing the full complex product.
- * In particular, I*Inf is corrupted to NaN+I*Inf, and I*-0 is corrupted
- * to -0.0+I*0.0.
- *
- * In C11, a CMPLX(x,y) macro was added to circumvent this limitation,
- * and gcc 4.7 added a __builtin_complex feature to simplify implementation
- * of CMPLX in libc, so we can take advantage of these features if they
- * are available.
- *
- * If __builtin_complex is not available, resort to using inline
- * functions instead. These can unfortunately not be used to construct
- * compile-time constants.
- */
-
-#define HAVE_BUILTIN_COMPLEX (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)) && !defined(__INTEL_COMPILER)
-
-#ifndef CMPLXF
-#if HAVE_BUILTIN_COMPLEX
-#  define CMPLXF(x,y) __builtin_complex ((float) (x), (float) (y))
-#else
-static __inline float complex
-CMPLXF(float x, float y)
-{
-	float_complex z;
-
-	REALPART(z) = x;
-	IMAGPART(z) = y;
-	return (z.f);
-}
-#endif
-#endif
-
-#ifndef CMPLX
-#if HAVE_BUILTIN_COMPLEX
-#  define CMPLX(x,y) __builtin_complex ((double) (x), (double) (y))
-#else
-static __inline double complex
-CMPLX(double x, double y)
-{
-	double_complex z;
-
-	REALPART(z) = x;
-	IMAGPART(z) = y;
-	return (z.f);
-}
-#endif
-#endif
-
-#ifndef CMPLXL
-#if HAVE_BUILTIN_COMPLEX
-#  define CMPLXL(x,y) __builtin_complex ((long double) (x), (long double) (y))
-#else
-static __inline long double complex
-CMPLXL(long double x, long double y)
-{
-	long_double_complex z;
-
-	REALPART(z) = x;
-	IMAGPART(z) = y;
-	return (z.f);
-}
-#endif
-#endif
-
-//VBS
-//#endif /* _COMPLEX_H */
 
 /*
  * Most of these functions depend on the rounding mode and have the side

--- a/src/openlibm.h
+++ b/src/openlibm.h
@@ -14,6 +14,10 @@
  * $FreeBSD: src/lib/msun/src/openlibm.h,v 1.82 2011/11/12 19:55:48 theraven Exp $
  */
 
+#ifdef OPENLIBM_USE_HOST_MATH_H
+#include <math.h>
+#else /* !OPENLIBM_USE_HOST_MATH_H */
+
 #ifndef OPENLIBM_H
 #define	OPENLIBM_H
 
@@ -487,3 +491,5 @@ long double	lgammal_r(long double, int *);
 }
 #endif
 #endif /* !OPENLIBM_H */
+
+#endif /* OPENLIBM_USE_HOST_MATH_H */

--- a/src/openlibm.h
+++ b/src/openlibm.h
@@ -14,10 +14,10 @@
  * $FreeBSD: src/lib/msun/src/openlibm.h,v 1.82 2011/11/12 19:55:48 theraven Exp $
  */
 
-#ifndef _MATH_H_
-#define	_MATH_H_
+#ifndef OPENLIBM_H
+#define	OPENLIBM_H
 
-#include <complex.h>
+#include <openlibm_complex.h>
 
 #if (defined(_WIN32) || defined (_MSC_VER)) && !defined(__WIN32__)
     #define __WIN32__
@@ -581,9 +581,7 @@ long double	truncl(long double);
 long double	lgammal_r(long double, int *);
 #endif	/* __BSD_VISIBLE */
 
-#include "openlibm_complex.h"
-
 #if defined(__cplusplus)
 }
 #endif
-#endif /* !_MATH_H_ */
+#endif /* !OPENLIBM_H */

--- a/src/openlibm_complex.h
+++ b/src/openlibm_complex.h
@@ -15,6 +15,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef OPENLIBM_USE_HOST_COMPLEX_H
+#include <complex.h>
+#else /* !OPENLIBM_USE_HOST_COMPLEX_H */
+
 #ifndef OPENLIBM_COMPLEX_H
 #define	OPENLIBM_COMPLEX_H
 
@@ -171,3 +175,5 @@ long double complex cprojl(long double complex);
 long double creall(long double complex);
 
 #endif /* !OPENLIBM_COMPLEX_H */
+
+#endif /* OPENLIBM_USE_HOST_COMPLEX_H */

--- a/src/openlibm_complex.h
+++ b/src/openlibm_complex.h
@@ -15,10 +15,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef _OPENLIBM_COMPLEX_H_
-#define	_OPENLIBM_COMPLEX_H_
+#ifndef OPENLIBM_COMPLEX_H
+#define	OPENLIBM_COMPLEX_H
 
-#include <sys/cdefs.h>
+#define complex _Complex
+
+#define _Complex_I 1.0fi
+#define I _Complex_I
 
 /*
  * Double versions of C99 functions
@@ -99,4 +102,4 @@ long double complex conjl(long double complex);
 long double complex cprojl(long double complex);
 long double creall(long double complex);
 
-#endif /* !_OPENLIBM_COMPLEX_H_ */
+#endif /* !OPENLIBM_COMPLEX_H */

--- a/src/openlibm_fenv.h
+++ b/src/openlibm_fenv.h
@@ -1,0 +1,9 @@
+#if defined(__arm__)
+#include "../arm/fenv.h"
+#elif defined(__x86_64__)
+#include "../amd64/fenv.h"
+#elif defined(__i386__)
+#include "../i387/fenv.h"
+#else
+#error "Unsupported platform"
+#endif

--- a/src/openlibm_fenv.h
+++ b/src/openlibm_fenv.h
@@ -1,3 +1,7 @@
+#ifdef OPENLIBM_USE_HOST_FENV_H
+#include <fenv.h>
+#else /* !OPENLIBM_USE_HOST_FENV_H */
+
 #if defined(__arm__)
 #include "../arm/fenv.h"
 #elif defined(__x86_64__)
@@ -7,3 +11,5 @@
 #else
 #error "Unsupported platform"
 #endif
+
+#endif /* OPENLIBM_USE_HOST_FENV_H */

--- a/src/polevll.c
+++ b/src/polevll.c
@@ -60,7 +60,7 @@
  *
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
 
 #include "math_private.h"
 

--- a/src/s_asinh.c
+++ b/src/s_asinh.c
@@ -24,7 +24,8 @@
  *		 := sign(x)*log1p(|x| + x^2/(1 + sqrt(1+x^2)))
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/s_asinhf.c
+++ b/src/s_asinhf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_asinhf.c,v 1.9 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/s_atan.c
+++ b/src/s_atan.c
@@ -34,8 +34,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double atanhi[] = {

--- a/src/s_atanf.c
+++ b/src/s_atanf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_atanf.c,v 1.10 2008/08/01 01:24:25 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float atanhi[] = {

--- a/src/s_atanl.c
+++ b/src/s_atanl.c
@@ -20,9 +20,9 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "invtrig.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 static const long double

--- a/src/s_cabs.c
+++ b/src/s_cabs.c
@@ -15,9 +15,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 double
 cabs(double complex z)

--- a/src/s_cabsf.c
+++ b/src/s_cabsf.c
@@ -15,8 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 float
 cabsf(float complex z)

--- a/src/s_cabsl.c
+++ b/src/s_cabsl.c
@@ -16,8 +16,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double
 cabsl(long double complex z)

--- a/src/s_cacos.c
+++ b/src/s_cacos.c
@@ -46,9 +46,9 @@
  *    IEEE      -10,+10     30000      1.8e-14      2.2e-15
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 double complex
 cacos(double complex z)

--- a/src/s_cacosf.c
+++ b/src/s_cacosf.c
@@ -46,8 +46,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 float complex
 cacosf(float complex z)

--- a/src/s_cacosh.c
+++ b/src/s_cacosh.c
@@ -42,9 +42,9 @@
  *
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 double complex
 cacosh(double complex z)

--- a/src/s_cacoshf.c
+++ b/src/s_cacoshf.c
@@ -42,8 +42,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 float complex
 cacoshf(float complex z)

--- a/src/s_cacoshl.c
+++ b/src/s_cacoshl.c
@@ -43,8 +43,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 cacoshl(long double complex z)

--- a/src/s_cacosl.c
+++ b/src/s_cacosl.c
@@ -47,8 +47,8 @@
  *    IEEE      -10,+10     30000      1.8e-14      2.2e-15
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 static const long double PIO2L = 1.570796326794896619231321691639751442098585L;
 

--- a/src/s_carg.c
+++ b/src/s_carg.c
@@ -27,8 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_carg.c,v 1.1 2007/12/12 23:43:51 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/s_cargf.c
+++ b/src/s_cargf.c
@@ -27,8 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cargf.c,v 1.1 2007/12/12 23:43:51 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/s_cargl.c
+++ b/src/s_cargl.c
@@ -27,8 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cargl.c,v 1.1 2008/07/31 22:41:26 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT long double

--- a/src/s_casin.c
+++ b/src/s_casin.c
@@ -49,9 +49,9 @@
  * Also tested by csin(casin(z)) = z.
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 double complex
 casin(double complex z)

--- a/src/s_casinf.c
+++ b/src/s_casinf.c
@@ -47,8 +47,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 float complex
 casinf(float complex z)

--- a/src/s_casinh.c
+++ b/src/s_casinh.c
@@ -42,9 +42,9 @@
  *
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 double complex
 casinh(double complex z)

--- a/src/s_casinhf.c
+++ b/src/s_casinhf.c
@@ -42,8 +42,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 float complex
 casinhf(float complex z)

--- a/src/s_casinhl.c
+++ b/src/s_casinhl.c
@@ -43,8 +43,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 casinhl(long double complex z)

--- a/src/s_casinl.c
+++ b/src/s_casinl.c
@@ -49,9 +49,9 @@
  * Also tested by csin(casin(z)) = z.
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 #if	LDBL_MANT_DIG == 64
 static const long double MACHEPL= 5.42101086242752217003726400434970855712890625E-20L;

--- a/src/s_catan.c
+++ b/src/s_catan.c
@@ -62,9 +62,9 @@
  * 2.9e-17.  See also clog().
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 #define MAXNUM 1.0e308
 

--- a/src/s_catanf.c
+++ b/src/s_catanf.c
@@ -59,8 +59,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 #define MAXNUMF 1.0e38F
 

--- a/src/s_catanh.c
+++ b/src/s_catanh.c
@@ -42,9 +42,9 @@
  *
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 double complex
 catanh(double complex z)

--- a/src/s_catanhf.c
+++ b/src/s_catanhf.c
@@ -42,8 +42,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 float complex
 catanhf(float complex z)

--- a/src/s_catanhl.c
+++ b/src/s_catanhl.c
@@ -43,8 +43,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 catanhl(long double complex z)

--- a/src/s_catanl.c
+++ b/src/s_catanl.c
@@ -63,9 +63,9 @@
  * 2.9e-17.  See also clog().
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 static const long double PIL = 3.141592653589793238462643383279502884197169L;
 static const long double DP1 = 3.14159265358979323829596852490908531763125L;

--- a/src/s_cbrt.c
+++ b/src/s_cbrt.c
@@ -15,7 +15,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cbrt.c,v 1.17 2011/03/12 16:50:39 kargl Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 /* cbrt(x)

--- a/src/s_cbrtf.c
+++ b/src/s_cbrtf.c
@@ -17,7 +17,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cbrtf.c,v 1.18 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 /* cbrtf(x)

--- a/src/s_cbrtl.c
+++ b/src/s_cbrtl.c
@@ -18,11 +18,11 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cbrtl.c,v 1.1 2011/03/12 19:37:35 kargl Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 // VBS
 //#include <ieeefp.h>
 
-#include "fpmath.h"    
-#include "openlibm.h"
+#include "fpmath.h"
 #include "math_private.h"
 #if defined(_WIN32) && defined(__i386__)
 #include "i387/bsd_ieeefp.h"

--- a/src/s_ccos.c
+++ b/src/s_ccos.c
@@ -49,9 +49,9 @@
  *    IEEE      -10,+10     30000       3.8e-16     1.0e-16
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 /* calculate cosh and sinh */
 

--- a/src/s_ccosf.c
+++ b/src/s_ccosf.c
@@ -48,8 +48,8 @@
  *    IEEE      -10,+10     30000       1.8e-7       5.5e-8
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 /* calculate cosh and sinh */
 

--- a/src/s_ccosh.c
+++ b/src/s_ccosh.c
@@ -37,8 +37,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_ccosh.c,v 1.2 2011/10/21 06:29:32 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_ccoshf.c
+++ b/src/s_ccoshf.c
@@ -31,8 +31,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_ccoshf.c,v 1.2 2011/10/21 06:29:32 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_ccoshl.c
+++ b/src/s_ccoshl.c
@@ -43,8 +43,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 ccoshl(long double complex z)

--- a/src/s_ccosl.c
+++ b/src/s_ccosl.c
@@ -50,8 +50,8 @@
  *    IEEE      -10,+10     30000       3.8e-16     1.0e-16
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 static void
 cchshl(long double x, long double *c, long double *s)

--- a/src/s_ceil.c
+++ b/src/s_ceil.c
@@ -23,8 +23,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double huge = 1.0e300;

--- a/src/s_ceilf.c
+++ b/src/s_ceilf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_ceilf.c,v 1.8 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float huge = 1.0e30;

--- a/src/s_cexp.c
+++ b/src/s_cexp.c
@@ -27,8 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cexp.c,v 1.3 2011/10/21 06:27:56 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_cexpf.c
+++ b/src/s_cexpf.c
@@ -27,8 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cexpf.c,v 1.3 2011/10/21 06:27:56 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_cexpl.c
+++ b/src/s_cexpl.c
@@ -54,8 +54,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 cexpl(long double complex z)

--- a/src/s_cimag.c
+++ b/src/s_cimag.c
@@ -26,8 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_cimag.c,v 1.3 2009/03/14 18:24:15 das Exp $
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/s_cimag.c
+++ b/src/s_cimag.c
@@ -26,7 +26,6 @@
  * $FreeBSD: src/lib/msun/src/s_cimag.c,v 1.3 2009/03/14 18:24:15 das Exp $
  */
 
-#include <openlibm.h>
 #include <openlibm_complex.h>
 
 #include "math_private.h"
@@ -34,7 +33,5 @@
 DLLEXPORT double
 cimag(double complex z)
 {
-	const double_complex z1 = { .f = z };
-
-	return (IMAGPART(z1));
+	return (__imag__ z);
 }

--- a/src/s_cimagf.c
+++ b/src/s_cimagf.c
@@ -26,7 +26,6 @@
  * $FreeBSD: src/lib/msun/src/s_cimagf.c,v 1.3 2009/03/14 18:24:15 das Exp $
  */
 
-#include <openlibm.h>
 #include <openlibm_complex.h>
 
 #include "math_private.h"
@@ -34,7 +33,5 @@
 DLLEXPORT float
 cimagf(float complex z)
 {
-	const float_complex z1 = { .f = z };
-
-	return (IMAGPART(z1));
+	return (__imag__ z);
 }

--- a/src/s_cimagf.c
+++ b/src/s_cimagf.c
@@ -26,8 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_cimagf.c,v 1.3 2009/03/14 18:24:15 das Exp $
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/s_cimagl.c
+++ b/src/s_cimagl.c
@@ -26,8 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_cimagl.c,v 1.3 2009/03/14 18:24:15 das Exp $
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT long double

--- a/src/s_cimagl.c
+++ b/src/s_cimagl.c
@@ -26,7 +26,6 @@
  * $FreeBSD: src/lib/msun/src/s_cimagl.c,v 1.3 2009/03/14 18:24:15 das Exp $
  */
 
-#include <openlibm.h>
 #include <openlibm_complex.h>
 
 #include "math_private.h"
@@ -34,7 +33,5 @@
 DLLEXPORT long double
 cimagl(long double complex z)
 {
-	const long_double_complex z1 = { .f = z };
-
-	return (IMAGPART(z1));
+	return (__imag__ z);
 }

--- a/src/s_clog.c
+++ b/src/s_clog.c
@@ -54,9 +54,9 @@
  * absolute error 1.0e-16.
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 double complex
 clog(double complex z)

--- a/src/s_clogf.c
+++ b/src/s_clogf.c
@@ -53,8 +53,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 float complex
 clogf(float complex z)

--- a/src/s_clogl.c
+++ b/src/s_clogl.c
@@ -55,8 +55,8 @@
  * absolute error 1.0e-16.
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 clogl(long double complex z)

--- a/src/s_conj.c
+++ b/src/s_conj.c
@@ -26,9 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_conj.c,v 1.2 2008/08/07 14:39:56 das Exp $
  */
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT double complex

--- a/src/s_conjf.c
+++ b/src/s_conjf.c
@@ -26,9 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_conjf.c,v 1.2 2008/08/07 14:39:56 das Exp $
  */
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT float complex

--- a/src/s_conjl.c
+++ b/src/s_conjl.c
@@ -26,9 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_conjl.c,v 1.2 2008/08/07 14:39:56 das Exp $
  */
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT long double complex

--- a/src/s_copysign.c
+++ b/src/s_copysign.c
@@ -19,7 +19,8 @@
  * with the sign bit of y.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/s_copysignf.c
+++ b/src/s_copysignf.c
@@ -22,7 +22,8 @@
  * with the sign bit of y.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/s_cos.c
+++ b/src/s_cos.c
@@ -45,8 +45,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 //#define INLINE_REM_PIO2
 #include "math_private.h"
 //#include "e_rem_pio2.c"

--- a/src/s_cosf.c
+++ b/src/s_cosf.c
@@ -18,8 +18,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cosf.c,v 1.18 2008/02/25 22:19:17 bde Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 //#define	INLINE_KERNEL_COSDF
 //#define	INLINE_KERNEL_SINDF
 //#define INLINE_REM_PIO2F

--- a/src/s_cosl.c
+++ b/src/s_cosl.c
@@ -33,8 +33,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 #if LDBL_MANT_DIG == 64
 #include "../ld80/e_rem_pio2l.h"

--- a/src/s_cpow.c
+++ b/src/s_cpow.c
@@ -44,9 +44,10 @@
  *
  */
 
-#include <complex.h>
 #include <float.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT double complex

--- a/src/s_cpowf.c
+++ b/src/s_cpowf.c
@@ -44,8 +44,9 @@
  *
  */
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT float complex

--- a/src/s_cpowl.c
+++ b/src/s_cpowl.c
@@ -45,8 +45,9 @@
  *
  */
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT long double complex

--- a/src/s_cproj.c
+++ b/src/s_cproj.c
@@ -27,8 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cproj.c,v 1.1 2008/08/07 15:07:48 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_cprojf.c
+++ b/src/s_cprojf.c
@@ -27,8 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cprojf.c,v 1.1 2008/08/07 15:07:48 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_cprojl.c
+++ b/src/s_cprojl.c
@@ -27,8 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_cprojl.c,v 1.1 2008/08/07 15:07:48 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_creal.c
+++ b/src/s_creal.c
@@ -26,7 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_creal.c,v 1.1 2004/05/30 09:21:56 stefanf Exp $
  */
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/s_crealf.c
+++ b/src/s_crealf.c
@@ -26,7 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_crealf.c,v 1.1 2004/05/30 09:21:56 stefanf Exp $
  */
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/s_creall.c
+++ b/src/s_creall.c
@@ -26,7 +26,9 @@
  * $FreeBSD: src/lib/msun/src/s_creall.c,v 1.1 2004/05/30 09:21:56 stefanf Exp $
  */
 
-#include <complex.h>
+#include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT long double

--- a/src/s_csin.c
+++ b/src/s_csin.c
@@ -51,9 +51,9 @@
  *
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 /* calculate cosh and sinh */
 

--- a/src/s_csinf.c
+++ b/src/s_csinf.c
@@ -49,8 +49,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 /* calculate cosh and sinh */
 

--- a/src/s_csinh.c
+++ b/src/s_csinh.c
@@ -37,8 +37,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_csinh.c,v 1.2 2011/10/21 06:29:32 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_csinhf.c
+++ b/src/s_csinhf.c
@@ -31,8 +31,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_csinhf.c,v 1.2 2011/10/21 06:29:32 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_csinhl.c
+++ b/src/s_csinhl.c
@@ -42,8 +42,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 csinhl(long double complex z)

--- a/src/s_csinl.c
+++ b/src/s_csinl.c
@@ -52,8 +52,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 static void
 cchshl(long double x, long double *c, long double *s)

--- a/src/s_csqrt.c
+++ b/src/s_csqrt.c
@@ -27,9 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_csqrt.c,v 1.4 2008/08/08 00:15:16 das Exp $");
 
-#include <complex.h>
 #include <float.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_csqrtf.c
+++ b/src/s_csqrtf.c
@@ -27,8 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_csqrtf.c,v 1.3 2008/08/08 00:15:16 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_csqrtl.c
+++ b/src/s_csqrtl.c
@@ -26,9 +26,9 @@
 
 #include "cdefs-compat.h"
 
-#include <complex.h>
 #include <float.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_ctan.c
+++ b/src/s_ctan.c
@@ -56,9 +56,9 @@
  * Also tested by ctan * ccot = 1 and catan(ctan(z))  =  z.
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 #define MACHEP 1.1e-16
 #define MAXNUM 1.0e308

--- a/src/s_ctanf.c
+++ b/src/s_ctanf.c
@@ -53,8 +53,8 @@
  *    IEEE      -10,+10     30000       3.3e-7       5.1e-8
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 #define MACHEPF 3.0e-8
 #define MAXNUMF 1.0e38f

--- a/src/s_ctanh.c
+++ b/src/s_ctanh.c
@@ -66,8 +66,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_ctanh.c,v 1.2 2011/10/21 06:30:16 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_ctanhf.c
+++ b/src/s_ctanhf.c
@@ -31,8 +31,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_ctanhf.c,v 1.2 2011/10/21 06:30:16 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
 
 #include "math_private.h"
 

--- a/src/s_ctanhl.c
+++ b/src/s_ctanhl.c
@@ -43,8 +43,8 @@
  *
  */
 
-#include <complex.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 long double complex
 ctanhl(long double complex z)

--- a/src/s_ctanl.c
+++ b/src/s_ctanl.c
@@ -56,9 +56,9 @@
  * Also tested by ctan * ccot = 1 and catan(ctan(z))  =  z.
  */
 
-#include <complex.h>
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
+#include <openlibm_complex.h>
 
 #if	LDBL_MANT_DIG == 64
 static const long double MACHEPL= 5.42101086242752217003726400434970855712890625E-20L;

--- a/src/s_erf.c
+++ b/src/s_erf.c
@@ -107,8 +107,8 @@
  *	   	erfc/erf(NaN) is NaN
  */
 
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/s_erff.c
+++ b/src/s_erff.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_erff.c,v 1.8 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/s_exp2.c
+++ b/src/s_exp2.c
@@ -28,8 +28,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_exp2.c,v 1.7 2008/02/22 02:27:34 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 #define	TBLBITS	8

--- a/src/s_exp2f.c
+++ b/src/s_exp2f.c
@@ -28,8 +28,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_exp2f.c,v 1.9 2008/02/22 02:27:34 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 #define	TBLBITS	4

--- a/src/s_expm1.c
+++ b/src/s_expm1.c
@@ -109,8 +109,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/s_expm1f.c
+++ b/src/s_expm1f.c
@@ -17,8 +17,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_expm1f.c,v 1.12 2011/10/21 06:26:38 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const float

--- a/src/s_fabs.c
+++ b/src/s_fabs.c
@@ -14,7 +14,8 @@
  * fabs(x) returns the absolute value of x.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/s_fabsf.c
+++ b/src/s_fabsf.c
@@ -20,7 +20,8 @@
  * fabsf(x) returns the absolute value of x.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/s_finite.c
+++ b/src/s_finite.c
@@ -18,7 +18,8 @@
  * no branching!
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT int

--- a/src/s_finitef.c
+++ b/src/s_finitef.c
@@ -21,7 +21,8 @@
  * no branching!
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT int

--- a/src/s_floor.c
+++ b/src/s_floor.c
@@ -23,8 +23,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double huge = 1.0e300;

--- a/src/s_floorf.c
+++ b/src/s_floorf.c
@@ -25,7 +25,8 @@
  *	Inexact flag raised if x not equal to floorf(x).
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float huge = 1.0e30;

--- a/src/s_fma.c
+++ b/src/s_fma.c
@@ -27,9 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_fma.c,v 1.8 2011/10/21 06:30:43 das Exp $");
 
-#include <fenv.h>
 #include <float.h>
 #include <openlibm.h>
+#include <openlibm_fenv.h>
 
 #include "math_private.h"
 

--- a/src/s_fmaf.c
+++ b/src/s_fmaf.c
@@ -27,8 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_fmaf.c,v 1.3 2011/10/15 04:16:58 das Exp $");
 
-#include "openlibm.h"
-#include "openlibm_fenv.h"
+#include <openlibm.h>
+#include <openlibm_fenv.h>
+
 #include "math_private.h"
 
 /*

--- a/src/s_fmaf.c
+++ b/src/s_fmaf.c
@@ -27,9 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_fmaf.c,v 1.3 2011/10/15 04:16:58 das Exp $");
 
-#include <fenv.h>
-
 #include "openlibm.h"
+#include "openlibm_fenv.h"
 #include "math_private.h"
 
 /*

--- a/src/s_fmal.c
+++ b/src/s_fmal.c
@@ -27,9 +27,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_fmal.c,v 1.7 2011/10/21 06:30:43 das Exp $");
 
-#include <fenv.h>
 #include <float.h>
 #include <openlibm.h>
+#include <openlibm_fenv.h>
 #include "math_private.h"
 #include "fpmath.h"
 

--- a/src/s_frexp.c
+++ b/src/s_frexp.c
@@ -24,8 +24,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/s_frexpf.c
+++ b/src/s_frexpf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_frexpf.c,v 1.10 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/s_ilogb.c
+++ b/src/s_ilogb.c
@@ -21,8 +21,8 @@
  */
 
 #include <limits.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT int

--- a/src/s_ilogbf.c
+++ b/src/s_ilogbf.c
@@ -17,8 +17,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_ilogbf.c,v 1.8 2008/02/22 02:30:35 das Exp $");
 
 #include <limits.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT int

--- a/src/s_log1p.c
+++ b/src/s_log1p.c
@@ -79,8 +79,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/s_log1pf.c
+++ b/src/s_log1pf.c
@@ -17,8 +17,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_log1pf.c,v 1.12 2008/03/29 16:37:59 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const float

--- a/src/s_logb.c
+++ b/src/s_logb.c
@@ -20,8 +20,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/s_logbf.c
+++ b/src/s_logbf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_logbf.c,v 1.9 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/s_lrint.c
+++ b/src/s_lrint.c
@@ -25,8 +25,8 @@
  */
 
 #include "cdefs-compat.h"
-#include <fenv.h>
 #include <openlibm.h>
+#include <openlibm_fenv.h>
 #include "math_private.h"
 
 #ifndef type

--- a/src/s_lround.c
+++ b/src/s_lround.c
@@ -29,8 +29,8 @@
 //#include <sys/limits.h>
 #include <limits.h>
 //VBS end
-#include <fenv.h>
 #include <openlibm.h>
+#include <openlibm_fenv.h>
 #include "math_private.h"
 
 #ifndef type

--- a/src/s_modf.c
+++ b/src/s_modf.c
@@ -20,7 +20,8 @@
  *	No exception.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double one = 1.0;

--- a/src/s_modff.c
+++ b/src/s_modff.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_modff.c,v 1.9 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float one = 1.0;

--- a/src/s_nearbyint.c
+++ b/src/s_nearbyint.c
@@ -27,8 +27,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_nearbyint.c,v 1.2 2008/01/14 02:12:06 das Exp $");
 
-#include <fenv.h>
 #include <openlibm.h>
+#include <openlibm_fenv.h>
 #include "math_private.h"
 
 /*

--- a/src/s_nextafter.c
+++ b/src/s_nextafter.c
@@ -21,8 +21,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/s_nextafterf.c
+++ b/src/s_nextafterf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_nextafterf.c,v 1.11 2008/02/22 02:30:35 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/s_nextafterl.c
+++ b/src/s_nextafterl.c
@@ -21,9 +21,9 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 #if LDBL_MAX_EXP != 0x4000

--- a/src/s_nexttoward.c
+++ b/src/s_nexttoward.c
@@ -20,9 +20,9 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 #if LDBL_MAX_EXP != 0x4000

--- a/src/s_nexttowardf.c
+++ b/src/s_nexttowardf.c
@@ -13,9 +13,9 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_nexttowardf.c,v 1.3 2011/02/10 07:38:38 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 #define	LDBL_INFNAN_EXP	(LDBL_MAX_EXP * 2 - 1)

--- a/src/s_remquo.c
+++ b/src/s_remquo.c
@@ -14,8 +14,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_remquo.c,v 1.2 2008/03/30 20:47:26 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double Zero[] = {0.0, -0.0,};

--- a/src/s_remquof.c
+++ b/src/s_remquof.c
@@ -13,7 +13,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_remquof.c,v 1.1 2005/03/25 04:40:44 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float Zero[] = {0.0, -0.0,};

--- a/src/s_remquol.c
+++ b/src/s_remquol.c
@@ -14,10 +14,10 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_remquol.c,v 1.2 2008/07/31 20:09:47 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 #include <stdint.h>
 
 #include "fpmath.h"
-#include "openlibm.h"
 #include "math_private.h"
 
 #define	BIAS (LDBL_MAX_EXP - 1)

--- a/src/s_rint.c
+++ b/src/s_rint.c
@@ -24,8 +24,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double

--- a/src/s_rintf.c
+++ b/src/s_rintf.c
@@ -17,9 +17,9 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_rintf.c,v 1.12 2008/02/22 02:30:35 das Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 #include <stdint.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const float

--- a/src/s_scalbn.c
+++ b/src/s_scalbn.c
@@ -18,9 +18,10 @@
  */
 
 #include "cdefs-compat.h"
-#include <float.h>
 
-#include "openlibm.h"
+#include <float.h>
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double

--- a/src/s_scalbnf.c
+++ b/src/s_scalbnf.c
@@ -16,7 +16,8 @@
 
 #include "cdefs-compat.h"
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float

--- a/src/s_signgam.c
+++ b/src/s_signgam.c
@@ -1,3 +1,5 @@
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
+
 int signgam = 0;

--- a/src/s_significand.c
+++ b/src/s_significand.c
@@ -19,7 +19,8 @@
  * for exercising the fraction-part(F) IEEE 754-1985 test vector.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/s_significandf.c
+++ b/src/s_significandf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_significandf.c,v 1.8 2008/02/22 02:30:36 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/s_sin.c
+++ b/src/s_sin.c
@@ -45,8 +45,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 //#define INLINE_REM_PIO2
 #include "math_private.h"
 //#include "e_rem_pio2.c"

--- a/src/s_sincos.c
+++ b/src/s_sincos.c
@@ -35,8 +35,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 //#define INLINE_REM_PIO2
 #include "math_private.h"
 //#include "e_rem_pio2.c"

--- a/src/s_sincosf.c
+++ b/src/s_sincosf.c
@@ -10,8 +10,9 @@
 */
 
 #include "cdefs-compat.h"
+
 #include <float.h>
-#include "openlibm.h"
+#include <openlibm.h>
 
 //#define	INLINE_KERNEL_COSDF
 //#define	INLINE_KERNEL_SINDF

--- a/src/s_sincosl.c
+++ b/src/s_sincosl.c
@@ -9,11 +9,11 @@
  * ====================================================
 */
 
- #include "cdefs-compat.h"
+#include "cdefs-compat.h"
 
- #include <float.h>
+#include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 #if LDBL_MANT_DIG == 64
 #include "../ld80/e_rem_pio2l.h"

--- a/src/s_sinf.c
+++ b/src/s_sinf.c
@@ -18,8 +18,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_sinf.c,v 1.17 2008/02/25 22:19:17 bde Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 //#define	INLINE_KERNEL_COSDF
 //#define	INLINE_KERNEL_SINDF
 //#define INLINE_REM_PIO2F

--- a/src/s_sinl.c
+++ b/src/s_sinl.c
@@ -28,8 +28,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_sinl.c,v 1.3 2011/05/30 19:41:28 kargl Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 #if LDBL_MANT_DIG == 64
 #include "../ld80/e_rem_pio2l.h"

--- a/src/s_tan.c
+++ b/src/s_tan.c
@@ -44,8 +44,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 //#define INLINE_REM_PIO2
 #include "math_private.h"
 //#include "e_rem_pio2.c"

--- a/src/s_tanf.c
+++ b/src/s_tanf.c
@@ -18,8 +18,8 @@
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_tanf.c,v 1.17 2008/02/25 22:19:17 bde Exp $");
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 //#define	INLINE_KERNEL_TANDF
 //#define INLINE_REM_PIO2F
 #include "math_private.h"

--- a/src/s_tanh.c
+++ b/src/s_tanh.c
@@ -37,7 +37,8 @@
  *	only tanh(0)=0 is exact for finite argument.
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const double one = 1.0, two = 2.0, tiny = 1.0e-300, huge = 1.0e300;

--- a/src/s_tanhf.c
+++ b/src/s_tanhf.c
@@ -16,7 +16,8 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/s_tanhf.c,v 1.9 2008/02/22 02:30:36 das Exp $");
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float one=1.0, two=2.0, tiny = 1.0e-30, huge = 1.0e30;

--- a/src/s_tanl.c
+++ b/src/s_tanl.c
@@ -34,8 +34,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 #if LDBL_MANT_DIG == 64
 #include "../ld80/e_rem_pio2l.h"

--- a/src/s_trunc.c
+++ b/src/s_trunc.c
@@ -23,8 +23,8 @@
  */
 
 #include <float.h>
+#include <openlibm.h>
 
-#include "openlibm.h"
 #include "math_private.h"
 
 static const double huge = 1.0e300;

--- a/src/s_truncf.c
+++ b/src/s_truncf.c
@@ -22,7 +22,8 @@
  *	Inexact flag raised if x not equal to truncf(x).
  */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 static const float huge = 1.0e30F;

--- a/src/w_cabs.c
+++ b/src/w_cabs.c
@@ -8,9 +8,10 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/w_cabs.c,v 1.7 2008/03/30 20:03:06 das Exp $");
 
-#include <complex.h>
 #include <float.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT double

--- a/src/w_cabsf.c
+++ b/src/w_cabsf.c
@@ -5,8 +5,9 @@
  * Placed into the Public Domain, 1994.
  */
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/src/w_cabsl.c
+++ b/src/w_cabsl.c
@@ -10,8 +10,9 @@
 #include "cdefs-compat.h"
 //__FBSDID("$FreeBSD: src/lib/msun/src/w_cabsl.c,v 1.1 2008/03/30 20:02:03 das Exp $");
 
-#include <complex.h>
 #include <openlibm.h>
+#include <openlibm_complex.h>
+
 #include "math_private.h"
 
 DLLEXPORT long double

--- a/src/w_dremf.c
+++ b/src/w_dremf.c
@@ -6,7 +6,8 @@
  */
 /* $FreeBSD: src/lib/msun/src/w_dremf.c,v 1.3 2004/07/28 05:53:18 kan Exp $ */
 
-#include "openlibm.h"
+#include <openlibm.h>
+
 #include "math_private.h"
 
 DLLEXPORT float

--- a/test/libm-test.c
+++ b/test/libm-test.c
@@ -116,16 +116,10 @@
 #endif
 
 #include "libm-test-ulps.h"
-#ifdef SYS_MATH_H /* XXX scp XXX */
-#include <complex.h>
-#include <math.h>
 #include <float.h>
-#include <fenv.h>
-#else
-#include "openlibm.h"
-#include "openlibm_fenv.h"
-#include "float.h"
-#endif
+#include <openlibm.h>
+#include <openlibm_complex.h>
+#include <openlibm_fenv.h>
 
 #if 0 /* XXX scp XXX */
 #define FE_INEXACT FE_INEXACT

--- a/test/libm-test.c
+++ b/test/libm-test.c
@@ -123,8 +123,8 @@
 #include <fenv.h>
 #else
 #include "openlibm.h"
+#include "openlibm_fenv.h"
 #include "float.h"
-#include "fenv.h"
 #endif
 
 #if 0 /* XXX scp XXX */

--- a/test/libm-test.c
+++ b/test/libm-test.c
@@ -2741,7 +2741,7 @@ fpclassify_test (void)
   check_int ("fpclassify (-inf) == FP_INFINITE", fpclassify (minus_infty), FP_INFINITE, 0, 0, 0);
   check_int ("fpclassify (+0) == FP_ZERO", fpclassify (plus_zero), FP_ZERO, 0, 0, 0);
   check_int ("fpclassify (-0) == FP_ZERO", fpclassify (minus_zero), FP_ZERO, 0, 0, 0);
-  check_int ("fpclassify (1000) == FP_NORMAL", fpclassify (1000), FP_NORMAL, 0, 0, 0);
+  check_int ("fpclassify (1000) == FP_NORMAL", fpclassify (1000.0), FP_NORMAL, 0, 0, 0);
 
   print_max_error ("fpclassify", 0, 0);
 }
@@ -2886,9 +2886,9 @@ isfinite_test (void)
 {
   init_max_error ();
 
-  check_bool ("isfinite (0) == true", isfinite (0), 1, 0, 0, 0);
+  check_bool ("isfinite (0) == true", isfinite (0.0), 1, 0, 0, 0);
   check_bool ("isfinite (-0) == true", isfinite (minus_zero), 1, 0, 0, 0);
-  check_bool ("isfinite (10) == true", isfinite (10), 1, 0, 0, 0);
+  check_bool ("isfinite (10) == true", isfinite (10.0), 1, 0, 0, 0);
   check_bool ("isfinite (inf) == false", isfinite (plus_infty), 0, 0, 0, 0);
   check_bool ("isfinite (-inf) == false", isfinite (minus_infty), 0, 0, 0, 0);
   check_bool ("isfinite (NaN) == false", isfinite (nan_value), 0, 0, 0, 0);
@@ -2901,9 +2901,9 @@ isnormal_test (void)
 {
   init_max_error ();
 
-  check_bool ("isnormal (0) == false", isnormal (0), 0, 0, 0, 0);
+  check_bool ("isnormal (0) == false", isnormal (0.0), 0, 0, 0, 0);
   check_bool ("isnormal (-0) == false", isnormal (minus_zero), 0, 0, 0, 0);
-  check_bool ("isnormal (10) == true", isnormal (10), 1, 0, 0, 0);
+  check_bool ("isnormal (10) == true", isnormal (10.0), 1, 0, 0, 0);
   check_bool ("isnormal (inf) == false", isnormal (plus_infty), 0, 0, 0, 0);
   check_bool ("isnormal (-inf) == false", isnormal (minus_infty), 0, 0, 0, 0);
   check_bool ("isnormal (NaN) == false", isnormal (nan_value), 0, 0, 0, 0);
@@ -3908,15 +3908,15 @@ signbit_test (void)
 
   init_max_error ();
 
-  check_bool ("signbit (0) == false", signbit (0), 0, 0, 0, 0);
+  check_bool ("signbit (0) == false", signbit (0.0), 0, 0, 0, 0);
   check_bool ("signbit (-0) == true", signbit (minus_zero), 1, 0, 0, 0);
   check_bool ("signbit (inf) == false", signbit (plus_infty), 0, 0, 0, 0);
   check_bool ("signbit (-inf) == true", signbit (minus_infty), 1, 0, 0, 0);
 
   /* signbit (x) != 0 for x < 0.  */
-  check_bool ("signbit (-1) == true", signbit (-1), 1, 0, 0, 0);
+  check_bool ("signbit (-1) == true", signbit (-1.0), 1, 0, 0, 0);
   /* signbit (x) == 0 for x >= 0.  */
-  check_bool ("signbit (1) == false", signbit (1), 0, 0, 0, 0);
+  check_bool ("signbit (1) == false", signbit (1.0), 0, 0, 0, 0);
 
   print_max_error ("signbit", 0, 0);
 }


### PR DESCRIPTION
Hi there,

First of all, thank you guys for being so responsive to all of my previous pull requests. Well appreciated!

Attached is a somewhat largish patchset that essentially decouples OpenLibm from the host system. It patches the code up in such a way that it no longer includes `<fenv.h>`, `<complex.h>` and `<math.h>`. Instead, it will use `<openlibm_fenv.h>`, `<openlibm_complex.h>` and `<openlibm.h>`. `<openlibm_complex.h>` has been patched up to become feature-complete.

I've added some bits to the `<openlibm*.h>` to switch building against the host headers. I can use this switch to build the math library for the POSIX-like environment I'm working on.

Thoughts?

Ed

[Edit: Fix formatting for the headers, they didn't show up for me otherwise - @Keno]