### PR TITLE
Fix build for x86 32 bit targets

### DIFF
--- a/src/s_cbrtl.c
+++ b/src/s_cbrtl.c
@@ -24,7 +24,7 @@
 
 #include "fpmath.h"
 #include "math_private.h"
-#if defined(_WIN32) && defined(__i386__)
+#if defined(__i386__)
 #include "i387/bsd_ieeefp.h"
 #endif
 


### PR DESCRIPTION
This would not build on i386 due to a missing include.

Namely nothing included bsd_ieeefp.h so it wouldn't build.