### PR TITLE
Add support for cross compiling with `make ARCH=name`

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -38,7 +38,9 @@ CC = gcc
 CFLAGS_add += -fno-gnu89-inline
 endif
 
-ARCH := $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
+ARCH ?= $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
+ARCH_ORIGIN := $(origin ARCH)
+
 ifeq ($(ARCH),mingw32)
 $(error "the mingw32 compiler you are using fails the openblas testsuite. please see the Julia README.windows.md document for a replacement")
 endif
@@ -48,12 +50,16 @@ CFLAGS_add += -std=c99 -Wall -O3 -I$(OPENLIBM_HOME) -I$(OPENLIBM_HOME)/include -
 default: all
 
 %.c.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS_add) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add) -c $< -o $@
 
 %.S.o: %.S
-	$(CC) $(SFLAGS) $(filter -m% -B% -I% -D%,$(CFLAGS_add)) -c $< -o $@
+	$(CC) $(SFLAGS) $(SFLAGS_add) $(filter -m% -B% -I% -D%,$(CFLAGS_add)) -c $< -o $@
 
 # OS-specific stuff
+REAL_ARCH := $(ARCH)
+ifeq ($(findstring arm,$(ARCH)),arm)
+override ARCH := arm
+endif
 ifeq ($(ARCH),i386)
 override ARCH := i387
 endif
@@ -102,3 +108,34 @@ SHLIB_EXT = dylib
 SONAME_FLAG = -install_name
 CFLAGS_add+=-fPIC
 endif
+
+# The target specific FLAGS_add
+ifeq ($(ARCH_ORIGIN),file)
+CFLAGS_add_TARGET_$(ARCH) :=
+SFLAGS_add_TARGET_$(ARCH) :=
+LDFLAGS_add_TARGET_$(ARCH) :=
+else
+ifeq ($(ARCH),i387)
+CFLAGS_add_TARGET_$(ARCH)  := -m32 -march=$(REAL_ARCH)
+SFLAGS_add_TARGET_$(ARCH)  := -m32 -march=$(REAL_ARCH)
+LDFLAGS_add_TARGET_$(ARCH) := -m32 -march=$(REAL_ARCH)
+endif
+CFLAGS_add_TARGET_x86_64  := -m64
+SFLAGS_add_TARGET_x86_64  := -m64
+LDFLAGS_add_TARGET_x86_64 := -m64
+# Arm
+ifeq ($(ARCH),arm)
+ifneq ($(REAL_ARCH),arm)
+CFLAGS_add_TARGET_$(ARCH)  := -march=$(REAL_ARCH)
+SFLAGS_add_TARGET_$(ARCH)  := -march=$(REAL_ARCH)
+LDFLAGS_add_TARGET_$(ARCH) := -march=$(REAL_ARCH)
+else
+$(error No known generic arm cflags. Please specify arch type)
+endif
+endif
+endif
+
+# Actually finish setting the FLAGS_add
+CFLAGS_add += $(CFLAGS_add_TARGET_$(ARCH))
+LDFLAGS_add += $(LDFLAGS_add_TARGET_$(ARCH))
+SFLAGS_add += $(SFLAGS_add_TARGET_$(ARCH))

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ libopenlibm.a: $(OBJS)
 	$(AR) -rcs libopenlibm.a $(OBJS)
 libopenlibm.$(SHLIB_EXT): $(OBJS)
 ifeq ($(OS),WINNT)
-	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
+	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
 else
-	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(SOMAJOR) -o libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
+	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(SOMAJOR) -o libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT).$(SOMAJOR)
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT)
 endif

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ includes experimental support for ARM.
    Linux and Windows.
 3. Use `make USECLANG=1` to build with clang. This is the default on OS X
    and FreeBSD.
+4. Use `make ARCH=i386` to build for i386. Other supported architectures are
+   i486, i586, i686, x86_64, and various arm architectures.

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,22 +6,22 @@ all: test-double test-float # test-double-system test-float-system
 bench: bench-syslibm bench-openlibm
 
 test-double: test-double.c libm-test.c
-	$(CC) $(CFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
+	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
 
 test-float: test-float.c libm-test.c
-	$(CC) $(CFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
+	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
 
 test-double-system: test-double.c libm-test.c
-	$(CC) $(CFLAGS) -g $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $< -DSYS_MATH_H -lm -o $@
 
 test-float-system: test-float.c libm-test.c
-	$(CC) $(CFLAGS) -g $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $< -DSYS_MATH_H -lm -o $@
 
 bench-openlibm: libm-bench.cpp
-	$(CC) $(CFLAGS) -O2 $< ../libopenlibm.a -o $@
+	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -O2 $< ../libopenlibm.a -o $@
 
 bench-syslibm: libm-bench.cpp
-	$(CC) $(CFLAGS) -O2 $< -lm -o $@
+	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -O2 $< -lm -o $@
 
 clean:
 	rm -fr test-double test-float test-double-system test-float-system bench-openlibm bench-syslibm *.dSYM


### PR DESCRIPTION
This is rather basic. A clean is needed to get rid of artifacts from
previous runs with other architectures.

Note this requires PR #88 to work because without it x86 is broken.

Closes #89