### PR TITLE
Update Make.inc to detect OpenBSD

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -103,6 +103,12 @@ SONAME_FLAG = -soname
 CFLAGS_add+=-fPIC
 endif
 
+ifeq ($(OS), OpenBSD)
+SHLIB_EXT = so
+SONAME_FLAG = -soname
+CFLAGS_add+=-fPIC
+endif
+
 ifeq ($(OS), Darwin)
 SHLIB_EXT = dylib
 SONAME_FLAG = -install_name

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ consistently across compilers and operating systems, and in 32-bit and
 
 ## Platform support
 
-OpenLibm builds on Linux, Mac OS X, Windows, and FreeBSD. It builds
+OpenLibm builds on Linux, Mac OS X, Windows, FreeBSD, and OpenBSD. It builds
 with both GCC and clang. Although largely tested on x86, it also
 includes experimental support for ARM.
 
@@ -27,3 +27,7 @@ includes experimental support for ARM.
    and FreeBSD.
 4. Use `make ARCH=i386` to build for i386. Other supported architectures are
    i486, i586, i686, x86_64, and various arm architectures.
+5. On OpenBSD, you need to install GNU Make (port name: `gmake`) and a recent
+   version of `gcc` (tested: 4.9.2), as the default version provided by OpenBSD
+   is too old (4.2.1). If you use OpenBSD's port system for this (port name:
+   `gcc`), run `make CC=egcc` to force Make to use the newer `gcc`.


### PR DESCRIPTION
With this patch I have been able to successfully compile Openlibm on OpenBSD 5.7 (x86_64) using the following command:

    gmake GCC=egcc GXX=eg++ USEGCC=1 ARCH=x86_64

I had to install gcc 4.9 from ports, as Openlibm does not compile with the default compiler shipped with OpenBSD 5.7, which is gcc 4.2.1. Also, gnumake must be installed for this to work.