### PR TITLE
Fix missing buildflags

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -53,7 +53,7 @@ default: all
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add) -c $< -o $@
 
 %.S.o: %.S
-	$(CC) $(SFLAGS) $(SFLAGS_add) $(filter -m% -B% -I% -D%,$(CFLAGS_add)) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(SFLAGS) $(SFLAGS_add) $(filter -m% -B% -I% -D%,$(CFLAGS_add)) -c $< -o $@
 
 # OS-specific stuff
 REAL_ARCH := $(ARCH)

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,22 +6,22 @@ all: test-double test-float # test-double-system test-float-system
 bench: bench-syslibm bench-openlibm
 
 test-double: test-double.c libm-test.c
-	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
 
 test-float: test-float.c libm-test.c
-	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
 
 test-double-system: test-double.c libm-test.c
-	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $< -DSYS_MATH_H -lm -o $@
 
 test-float-system: test-float.c libm-test.c
-	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -g $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $< -DSYS_MATH_H -lm -o $@
 
 bench-openlibm: libm-bench.cpp
-	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -O2 $< ../libopenlibm.a -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -O2 $< ../libopenlibm.a -o $@
 
 bench-syslibm: libm-bench.cpp
-	$(CC) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) -O2 $< -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -O2 $< -lm -o $@
 
 clean:
 	rm -fr test-double test-float test-double-system test-float-system bench-openlibm bench-syslibm *.dSYM


### PR DESCRIPTION
Debian's blhc (build log hardening check) reports dpkg-buildflags-missing CPPFLAGS 48 (of 223), CFLAGS 2 (of 177), LDFLAGS 2 (of 3) missing