### PR TITLE
Make OpenLibm build on AArch64 (aka ARM64).

### DIFF
--- a/ld128/e_lgammal_r.c
+++ b/ld128/e_lgammal_r.c
@@ -763,7 +763,7 @@ lgammal_r(long double x, int *signgamp)
 
   *signgamp = 1;
 
-  if (! finite (x))
+  if (!isfinite (x))
     return x * x;
 
   if (x == 0.0L)

--- a/ld128/e_rem_pio2l.h
+++ b/ld128/e_rem_pio2l.h
@@ -58,7 +58,11 @@ pio2_2t =  2.0670321098263988236496903051604844e-43L,	/*  0x127044533e63a0105df5
 pio2_3  =  2.0670321098263988236499468110329591e-43L,	/*  0x127044533e63a0105e00000000000.0p-254 */
 pio2_3t = -2.5650587247459238361625433492959285e-65L;	/* -0x159c4ec64ddaeb5f78671cbfb2210.0p-327 */
 
-static inline __always_inline int
+//VBS
+//static inline __always_inline int
+//__ieee754_rem_pio2l(long double x, long double *y)
+
+static inline int
 __ieee754_rem_pio2l(long double x, long double *y)
 {
 	union IEEEl2bits u,u1;

--- a/src/aarch64_fpmath.h
+++ b/src/aarch64_fpmath.h
@@ -1,0 +1,58 @@
+/*-
+ * Copyright (c) 2002, 2003 David Schultz <das@FreeBSD.ORG>
+ * Copyright (2) 2014 The FreeBSD Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: head/lib/libc/aarch64/_fpmath.h 281197 2015-04-07 09:52:14Z andrew $
+ */
+
+union IEEEl2bits {
+	long double	e;
+	struct {
+		unsigned long	manl	:64;
+		unsigned long	manh	:48;
+		unsigned int	exp	:15;
+		unsigned int	sign	:1;
+	} bits;
+	/* TODO andrew: Check the packing here */
+	struct {
+		unsigned long	manl	:64;
+		unsigned long	manh	:48;
+		unsigned int	expsign	:16;
+	} xbits;
+};
+
+#define	LDBL_NBIT	0
+#define	LDBL_IMPLICIT_NBIT
+#define	mask_nbit_l(u)	((void)0)
+
+#define	LDBL_MANH_SIZE	48
+#define	LDBL_MANL_SIZE	64
+
+#define	LDBL_TO_ARRAY32(u, a) do {			\
+	(a)[0] = (uint32_t)(u).bits.manl;		\
+	(a)[1] = (uint32_t)((u).bits.manl >> 32);	\
+	(a)[2] = (uint32_t)(u).bits.manh;		\
+	(a)[3] = (uint32_t)((u).bits.manh >> 32);	\
+} while(0)

--- a/src/fpmath.h
+++ b/src/fpmath.h
@@ -29,8 +29,9 @@
 #ifndef _FPMATH_H_
 #define _FPMATH_H_
 
-// Currently assumes Intel platform
-#if defined (__i386__) || defined(__x86_64__)
+#if defined(__aarch64__)
+#include "aarch64_fpmath.h"
+#elif defined(__i386__) || defined(__x86_64__)
 #ifdef __LP64__
 #include "amd64_fpmath.h"
 #else 


### PR DESCRIPTION
CloudABI's C library (cloudlibc) used a stock version of OpenLibm for its math functions. I recently added support for another architecture, AArch64, which required me to make a couple of small changes to the sources.

The following changes make it possible to use a stock version of OpenLibm once more.