### PR TITLE
Build on GNU/kfreeBSD and GNU/Hurd

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -82,37 +82,22 @@ override OS=WINNT
 endif
 
 #keep these if statements separate
+
 ifeq ($(OS), WINNT)
-SHLIB_EXT = dll
-SONAME_FLAG = -soname
-CFLAGS_add += -nodefaultlibs
-shlibdir = $(bindir)
-else
-shlibdir = $(libdir)
-endif
-
-ifeq ($(OS), Linux)
-SHLIB_EXT = so
-SONAME_FLAG = -soname
-CFLAGS_add+=-fPIC
-endif
-
-ifeq ($(OS), FreeBSD)
-SHLIB_EXT = so
-SONAME_FLAG = -soname
-CFLAGS_add+=-fPIC
-endif
-
-ifeq ($(OS), OpenBSD)
-SHLIB_EXT = so
-SONAME_FLAG = -soname
-CFLAGS_add+=-fPIC
-endif
-
-ifeq ($(OS), Darwin)
-SHLIB_EXT = dylib
-SONAME_FLAG = -install_name
-CFLAGS_add+=-fPIC
+  SHLIB_EXT = dll
+  SONAME_FLAG = -soname
+  override CFLAGS_add += -nodefaultlibs
+  shlibdir = $(bindir)
+ else
+  ifeq ($(OS), Darwin)
+    SHLIB_EXT = dylib
+    SONAME_FLAG = -install_name
+  else
+    SHLIB_EXT = so
+    SONAME_FLAG = -soname
+  endif
+  override CFLAGS_add += -fPIC
+  shlibdir = $(libdir)
 endif
 
 # The target specific FLAGS_add

--- a/amd64/bsd_asm.h
+++ b/amd64/bsd_asm.h
@@ -62,7 +62,7 @@
 
 #define _START_ENTRY	.p2align 4,0x90
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__ELF__)
+#if defined(__ELF__)
 #define _ENTRY(x)	.text; _START_ENTRY; \
 			.globl CNAME(x); .type CNAME(x),@function; CNAME(x):
 #define	END(x)		.size x, . - x

--- a/amd64/e_remainder.S
+++ b/amd64/e_remainder.S
@@ -25,6 +25,6 @@ ENTRY(remainder)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/e_remainderf.S
+++ b/amd64/e_remainderf.S
@@ -24,6 +24,6 @@ ENTRY(remainderf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/e_remainderl.S
+++ b/amd64/e_remainderl.S
@@ -30,6 +30,6 @@ ENTRY(remainderl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/e_sqrt.S
+++ b/amd64/e_sqrt.S
@@ -35,6 +35,6 @@ END(sqrt)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/e_sqrtf.S
+++ b/amd64/e_sqrtf.S
@@ -34,6 +34,6 @@ END(sqrtf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/e_sqrtl.S
+++ b/amd64/e_sqrtl.S
@@ -41,6 +41,6 @@ ENTRY(sqrtl)
 	ret
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_llrint.S
+++ b/amd64/s_llrint.S
@@ -7,6 +7,6 @@ ENTRY(llrint)
 END(llrint)
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_llrintf.S
+++ b/amd64/s_llrintf.S
@@ -7,6 +7,6 @@ ENTRY(llrintf)
 END(llrintf)
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_llrintl.S
+++ b/amd64/s_llrintl.S
@@ -40,6 +40,6 @@ ENTRY(llrintl)
 
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_logbl.S
+++ b/amd64/s_logbl.S
@@ -24,6 +24,6 @@ ENTRY(logbl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_lrint.S
+++ b/amd64/s_lrint.S
@@ -39,6 +39,6 @@ END(lrint)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_lrintf.S
+++ b/amd64/s_lrintf.S
@@ -39,6 +39,6 @@ END(lrintf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_lrintl.S
+++ b/amd64/s_lrintl.S
@@ -40,6 +40,6 @@ ENTRY(lrintl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_remquo.S
+++ b/amd64/s_remquo.S
@@ -71,6 +71,6 @@ END(remquo)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_remquof.S
+++ b/amd64/s_remquof.S
@@ -71,6 +71,6 @@ END(remquof)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_remquol.S
+++ b/amd64/s_remquol.S
@@ -76,6 +76,6 @@ ENTRY(remquol)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_rintl.S
+++ b/amd64/s_rintl.S
@@ -21,6 +21,6 @@ ENTRY(rintl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_scalbn.S
+++ b/amd64/s_scalbn.S
@@ -50,6 +50,6 @@ END(scalbn)
 .set   CNAME(ldexp),CNAME(scalbn)
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_scalbnf.S
+++ b/amd64/s_scalbnf.S
@@ -50,6 +50,6 @@ END(scalbnf)
 .set   CNAME(ldexpf),CNAME(scalbnf)
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/amd64/s_scalbnl.S
+++ b/amd64/s_scalbnl.S
@@ -35,6 +35,6 @@ END(scalbnl)
 .set   CNAME(ldexpl),CNAME(scalbnl)
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/bsd_asm.h
+++ b/i387/bsd_asm.h
@@ -72,7 +72,7 @@
 /* XXX should use .p2align 4,0x90 for -m486. */
 #define _START_ENTRY .p2align 2,0x90
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__ELF__)
+#if defined(__ELF__)
 #define CNAME(csym)		csym
 #define HIDENAME(asmsym)	.asmsym
 #define _ENTRY(x) .text; _START_ENTRY; \

--- a/i387/bsd_asm.h
+++ b/i387/bsd_asm.h
@@ -39,7 +39,7 @@
 #if defined(__APPLE__)
 #include "osx_asm.h"
 #define CNAME(x) EXT(x)
-#elif defined(__FreeBSD__) || defined(__linux__) || defined(_WIN32)
+#else
 #include "bsd_cdefs.h"
 
 #ifdef PIC

--- a/i387/e_exp.S
+++ b/i387/e_exp.S
@@ -71,6 +71,6 @@ END(exp)
     //
 
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_fmod.S
+++ b/i387/e_fmod.S
@@ -20,6 +20,6 @@ END(fmod)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_log.S
+++ b/i387/e_log.S
@@ -16,6 +16,6 @@ END(log)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_log10.S
+++ b/i387/e_log10.S
@@ -16,6 +16,6 @@ END(log10)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_log10f.S
+++ b/i387/e_log10f.S
@@ -17,6 +17,6 @@ END(log10f)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_logf.S
+++ b/i387/e_logf.S
@@ -16,6 +16,6 @@ ENTRY(logf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_remainder.S
+++ b/i387/e_remainder.S
@@ -20,6 +20,6 @@ END(remainder)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_remainderf.S
+++ b/i387/e_remainderf.S
@@ -21,6 +21,6 @@ END(remainderf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_remainderl.S
+++ b/i387/e_remainderl.S
@@ -20,6 +20,6 @@ ENTRY(remainderl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_sqrt.S
+++ b/i387/e_sqrt.S
@@ -15,6 +15,6 @@ END(sqrt)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_sqrtf.S
+++ b/i387/e_sqrtf.S
@@ -16,6 +16,6 @@ END(sqrtf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/e_sqrtl.S
+++ b/i387/e_sqrtl.S
@@ -14,6 +14,6 @@ ENTRY(sqrtl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_ceil.S
+++ b/i387/s_ceil.S
@@ -29,6 +29,6 @@ END(ceil)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_ceilf.S
+++ b/i387/s_ceilf.S
@@ -31,6 +31,6 @@ END(ceilf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_ceill.S
+++ b/i387/s_ceill.S
@@ -29,6 +29,6 @@ END(ceill)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_copysign.S
+++ b/i387/s_copysign.S
@@ -20,6 +20,6 @@ END(copysign)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_copysignf.S
+++ b/i387/s_copysignf.S
@@ -21,6 +21,6 @@ END(copysignf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_copysignl.S
+++ b/i387/s_copysignl.S
@@ -19,6 +19,6 @@ END(copysignl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_cos.S
+++ b/i387/s_cos.S
@@ -28,6 +28,6 @@ END(cos)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_floor.S
+++ b/i387/s_floor.S
@@ -30,6 +30,6 @@ END(floor)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_floorf.S
+++ b/i387/s_floorf.S
@@ -31,6 +31,6 @@ END(floorf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_floorl.S
+++ b/i387/s_floorl.S
@@ -29,6 +29,6 @@ END(floorl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_llrint.S
+++ b/i387/s_llrint.S
@@ -38,6 +38,6 @@ END(llrint)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_llrintf.S
+++ b/i387/s_llrintf.S
@@ -38,6 +38,6 @@ END(llrintf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_llrintl.S
+++ b/i387/s_llrintl.S
@@ -37,6 +37,6 @@ ENTRY(llrintl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_logb.S
+++ b/i387/s_logb.S
@@ -16,6 +16,6 @@ END(logb)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_logbf.S
+++ b/i387/s_logbf.S
@@ -17,6 +17,6 @@ END(logbf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_logbl.S
+++ b/i387/s_logbl.S
@@ -15,6 +15,6 @@ ENTRY(logbl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_lrint.S
+++ b/i387/s_lrint.S
@@ -37,6 +37,6 @@ END(lrint)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_lrintf.S
+++ b/i387/s_lrintf.S
@@ -37,6 +37,6 @@ END(lrintf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_lrintl.S
+++ b/i387/s_lrintl.S
@@ -36,6 +36,6 @@ ENTRY(lrintl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_remquo.S
+++ b/i387/s_remquo.S
@@ -64,6 +64,6 @@ END(remquo)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_remquof.S
+++ b/i387/s_remquof.S
@@ -64,6 +64,6 @@ END(remquof)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_remquol.S
+++ b/i387/s_remquol.S
@@ -64,6 +64,6 @@ ENTRY(remquol)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_rint.S
+++ b/i387/s_rint.S
@@ -15,6 +15,6 @@ END(rint)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_rintf.S
+++ b/i387/s_rintf.S
@@ -16,6 +16,6 @@ END(rintf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_rintl.S
+++ b/i387/s_rintl.S
@@ -14,6 +14,6 @@ ENTRY(rintl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_scalbn.S
+++ b/i387/s_scalbn.S
@@ -18,6 +18,6 @@ END(scalbn)
 .globl CNAME(ldexp)
 .set   CNAME(ldexp),CNAME(scalbn)
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_scalbnf.S
+++ b/i387/s_scalbnf.S
@@ -21,6 +21,6 @@ END(scalbnf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_scalbnl.S
+++ b/i387/s_scalbnl.S
@@ -21,6 +21,6 @@ END(scalbnl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_sin.S
+++ b/i387/s_sin.S
@@ -28,6 +28,6 @@ END(sin)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_tan.S
+++ b/i387/s_tan.S
@@ -30,6 +30,6 @@ END(tan)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_trunc.S
+++ b/i387/s_trunc.S
@@ -28,6 +28,6 @@ END(trunc)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_truncf.S
+++ b/i387/s_truncf.S
@@ -28,6 +28,6 @@ END(truncf)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/i387/s_truncl.S
+++ b/i387/s_truncl.S
@@ -28,6 +28,6 @@ END(truncl)
 
 	
 /* Enable stack protection */
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/src/fpmath.h
+++ b/src/fpmath.h
@@ -47,7 +47,7 @@
 #define _PDP_ENDIAN       __ORDER_PDP_ENDIAN__
 #define _BYTE_ORDER       __BYTE_ORDER__
 
-#elif defined(__linux)
+#elif defined(__GLIBC__)
 
 #include <features.h>
 #include <endian.h>

--- a/src/types-compat.h
+++ b/src/types-compat.h
@@ -5,7 +5,7 @@
 #include <limits.h>
 #include <stdint.h>
 
-#ifdef __linux__
+#ifdef __GLIBC__
 /* Not sure what to do about __pure2 on linux */
 #define __pure2 
 #endif


### PR DESCRIPTION
Debian's GNU/kFreeBSD port consists of a GNU userland using the GNU C library on top of a FreeBSD kernel.  Similarly, Debian's GNU/Hurd runs on top of the GNU Mach microkernel.