### PR TITLE
Add missing include to inline __fpgetprec on i386

### DIFF
--- a/ld80/s_exp2l.c
+++ b/ld80/s_exp2l.c
@@ -30,6 +30,7 @@
 #include <float.h>
 #include <stdint.h>
 
+#include "amd64/bsd_cdefs.h"
 #include "amd64/bsd_ieeefp.h"
 
 #include <openlibm_math.h>


### PR DESCRIPTION
This fixes the unresolved symbol __fpgetprec in libopenlibm.so.1.0 on i386