### PR TITLE
Test shared library

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -21,5 +21,4 @@ arm32)
 	;;
 esac
 
-$LOADER ./test/test-double
-$LOADER ./test/test-float
+$LOADER make check

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,17 @@ OBJS =  $(patsubst %.f,%.f.o,\
 	$(patsubst %.S,%.S.o,\
 	$(patsubst %.c,%.c.o,$(filter-out $(addprefix src/,$(DUPLICATE_SRCS)),$(SRCS)))))
 
+.PHONY: all check test clean distclean install
+
 all: libopenlibm.a libopenlibm.$(SHLIB_EXT) 
-	$(MAKE) -C test
+
+check test: test/test-double test/test-float
+	test/test-double
+	test/test-float
+
 libopenlibm.a: $(OBJS)  
 	$(AR) -rcs libopenlibm.a $(OBJS)
+
 libopenlibm.$(SHLIB_EXT): $(OBJS)
 ifeq ($(OS),WINNT)
 	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
@@ -36,6 +43,12 @@ else
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT).$(SOMAJOR)
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT)
 endif
+
+test/test-double: libopenlibm.$(SHLIB_EXT)
+	$(MAKE) -C test test-double
+
+test/test-float: libopenlibm.$(SHLIB_EXT)
+	$(MAKE) -C test test-float
 
 clean:
 	@for dir in $(SUBDIRS) .; do \

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,15 +1,18 @@
 OPENLIBM_HOME=$(abspath ..)
 include ../Make.inc
 
+# Set rpath of tests to builddir for loading shared library
+OPENLIBM_LIB = -L.. -lopenlibm -Wl,-rpath=$(OPENLIBM_HOME)
+
 all: test-double test-float # test-double-system test-float-system
 
 bench: bench-syslibm bench-openlibm
 
 test-double: test-double.c libm-test.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
 
 test-float: test-float.c libm-test.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src ../libopenlibm.a -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
 
 test-double-system: test-double.c libm-test.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $< -DSYS_MATH_H -lm -o $@
@@ -18,7 +21,7 @@ test-float-system: test-float.c libm-test.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $< -DSYS_MATH_H -lm -o $@
 
 bench-openlibm: libm-bench.cpp
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -O2 $< ../libopenlibm.a -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -O2 $< $(OPENLIBM_LIB) -o $@
 
 bench-syslibm: libm-bench.cpp
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -O2 $< -lm -o $@


### PR DESCRIPTION
This patch adds a make check target that builds and runs the tests using the shared library.

This is a prerequisite for resolving issue #99.