### PR TITLE
Set default optimization flag to -O2

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -22,3 +22,5 @@ arm32)
 esac
 
 $LOADER make check
+
+make clean && git status --ignored --porcelain && test -z "$(git status --ignored --porcelain)"

--- a/Make.inc
+++ b/Make.inc
@@ -47,9 +47,8 @@ endif
 
 CFLAGS_add += -std=c99 -Wall -I$(OPENLIBM_HOME) -I$(OPENLIBM_HOME)/include -I$(OPENLIBM_HOME)/ld80 -I$(OPENLIBM_HOME)/$(ARCH) -I$(OPENLIBM_HOME)/src -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration
 
-ifneq ($(NOOPT),1)
-CFLAGS_add += -O3
-endif
+# The optimization flag may be overriden with the environment variable CFLAGS.
+CFLAGS ?= -O2
 
 default: all
 

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,9 @@ test/test-float: libopenlibm.$(SHLIB_EXT)
 	$(MAKE) -C test test-float
 
 clean:
-	@for dir in $(SUBDIRS) .; do \
-		rm -fr $$dir/*.o $$dir/*.a $$dir/*.$(SHLIB_EXT)*; \
-	done
-	@rm -f test/test-double test/test-float
-
-distclean:
-	-rm -f $(OBJS) *.a *.$(SHLIB_EXT) libopenlibm.*
-	-$(MAKE) -C test clean
+	rm -f amd64/*.o arm/*.o bsdsrc/*.o i387/*.o ld128/*.o ld80/*.o src/*.o
+	rm -f libopenlibm.a libopenlibm.$(SHLIB_EXT)*
+	$(MAKE) -C test clean
 
 openlibm.pc: openlibm.pc.in Make.inc Makefile
 	echo "prefix=${prefix}" > openlibm.pc

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ ifeq ($(OS),WINNT)
 	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
 else
 	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(SOMAJOR) -o libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
-	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT).$(SOMAJOR)
-	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT)
+	ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT).$(SOMAJOR)
+	ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT)
 endif
 
 test/test-double: libopenlibm.$(SHLIB_EXT)

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,22 +12,22 @@ all: test-double test-float # test-double-system test-float-system
 bench: bench-syslibm bench-openlibm
 
 test-double: test-double.c libm-test.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
 
 test-float: test-float.c libm-test.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
 
 test-double-system: test-double.c libm-test.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< -DSYS_MATH_H -lm -o $@
 
 test-float-system: test-float.c libm-test.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -g $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< -DSYS_MATH_H -lm -o $@
 
 bench-openlibm: libm-bench.cpp
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -O2 $< $(OPENLIBM_LIB) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< $(OPENLIBM_LIB) -o $@
 
 bench-syslibm: libm-bench.cpp
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) -O2 $< -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< -lm -o $@
 
 clean:
 	rm -fr test-double test-float test-double-system test-float-system bench-openlibm bench-syslibm *.dSYM


### PR DESCRIPTION
This sets the default optimization level to -O2 as discussed in issue #105. The optimization flag may be overriden with CFLAGS, which the canonical way in distributions such as Debian.

On a general note, please allow sufficient time to the openlibm team members to review before merging.