### PR TITLE
fix ARCH variable for powerpc, and rearrange fenv.h union for endianness

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -73,6 +73,9 @@ REAL_ARCH := $(ARCH)
 ifeq ($(findstring arm,$(ARCH)),arm)
 override ARCH := arm
 endif
+ifeq ($(findstring powerpc,$(ARCH)),powerpc)
+override ARCH := powerpc
+endif
 ifeq ($(ARCH),i386)
 override ARCH := i387
 endif

--- a/Make.inc
+++ b/Make.inc
@@ -76,6 +76,9 @@ endif
 ifeq ($(findstring powerpc,$(ARCH)),powerpc)
 override ARCH := powerpc
 endif
+ifeq ($(findstring ppc,$(ARCH)),ppc)
+override ARCH := powerpc
+endif
 ifeq ($(ARCH),i386)
 override ARCH := i387
 endif

--- a/include/openlibm_fenv_powerpc.h
+++ b/include/openlibm_fenv_powerpc.h
@@ -97,8 +97,13 @@ extern const fenv_t	__fe_dfl_env;
 union __fpscr {
 	double __d;
 	struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+		fenv_t __reg;
+		__uint32_t __junk;
+#else
 		__uint32_t __junk;
 		fenv_t __reg;
+#endif
 	} __bits;
 };
 


### PR DESCRIPTION
Fixes #120

Do we want to push the changes to fenv upstream to FreeBSD?