### PR TITLE
Revert "Fix #35"

### DIFF
--- a/include/openlibm_fenv_amd64.h
+++ b/include/openlibm_fenv_amd64.h
@@ -95,7 +95,7 @@ extern const fenv_t	__fe_dfl_env;
 #define	__ldmxcsr(__csr)	__asm __volatile("ldmxcsr %0" : : "m" (__csr))
 #define	__stmxcsr(__csr)	__asm __volatile("stmxcsr %0" : "=m" (*(__csr)))
 
-__fenv_static __attribute__((always_inline)) DLLEXPORT inline int
+__fenv_static __attribute__((always_inline)) inline int
 feclearexcept(int __excepts)
 {
 	fenv_t __env;
@@ -113,7 +113,7 @@ feclearexcept(int __excepts)
 	return (0);
 }
 
-__fenv_static DLLEXPORT inline int
+__fenv_static inline int
 fegetexceptflag(fexcept_t *__flagp, int __excepts)
 {
 	uint32_t __mxcsr;
@@ -125,10 +125,10 @@ fegetexceptflag(fexcept_t *__flagp, int __excepts)
 	return (0);
 }
 
-DLLEXPORT int fesetexceptflag(const fexcept_t *__flagp, int __excepts);
-DLLEXPORT int feraiseexcept(int __excepts);
+int fesetexceptflag(const fexcept_t *__flagp, int __excepts);
+int feraiseexcept(int __excepts);
 
-__fenv_static __attribute__((always_inline)) DLLEXPORT inline int
+__fenv_static __attribute__((always_inline)) inline int
 fetestexcept(int __excepts)
 {
 	uint32_t __mxcsr;
@@ -139,7 +139,7 @@ fetestexcept(int __excepts)
 	return ((__status | __mxcsr) & __excepts);
 }
 
-__fenv_static DLLEXPORT inline int
+__fenv_static inline int
 fegetround(void)
 {
 	uint16_t __control;
@@ -154,7 +154,7 @@ fegetround(void)
 	return (__control & _ROUND_MASK);
 }
 
-__fenv_static DLLEXPORT inline int
+__fenv_static inline int
 fesetround(int __round)
 {
 	uint32_t __mxcsr;
@@ -176,10 +176,10 @@ fesetround(int __round)
 	return (0);
 }
 
-DLLEXPORT int fegetenv(fenv_t *__envp);
-DLLEXPORT int feholdexcept(fenv_t *__envp);
+int fegetenv(fenv_t *__envp);
+int feholdexcept(fenv_t *__envp);
 
-__fenv_static DLLEXPORT inline int
+__fenv_static inline int
 fesetenv(const fenv_t *__envp)
 {
 
@@ -196,15 +196,15 @@ fesetenv(const fenv_t *__envp)
 	return (0);
 }
 
-DLLEXPORT int feupdateenv(const fenv_t *__envp);
+int feupdateenv(const fenv_t *__envp);
 
 #if __BSD_VISIBLE
 
-DLLEXPORT int feenableexcept(int __mask);
-DLLEXPORT int fedisableexcept(int __mask);
+int feenableexcept(int __mask);
+int fedisableexcept(int __mask);
 
 /* We currently provide no external definition of fegetexcept(). */
-static inline DLLEXPORT int
+static inline int
 fegetexcept(void)
 {
 	uint16_t __control;


### PR DESCRIPTION
This reverts commit 8b3b52067563a5a212a7fbacf360907fe2dc5e57.
This was causing dllexport-related errors on win64, as seen in https://ci.appveyor.com/project/StefanKarpinski/julia/build/1.0.13704/job/ldq0cqvw68h933hy. If there's another way to fix the clang warnings that doesn't break the windows build, it's worth trying.