### PR TITLE
More header fixes

### DIFF
--- a/i387/fenv.c
+++ b/i387/fenv.c
@@ -26,10 +26,10 @@
  * $FreeBSD: src/lib/msun/i387/fenv.c,v 1.8 2011/10/21 06:25:31 das Exp $
  */
 
-#include <cdefs-compat.h>
-#include <types-compat.h>
-#include <math_private.h>
-#include <i387/bsd_npx.h>
+#include "cdefs-compat.h"
+#include "types-compat.h"
+#include "math_private.h"
+#include "i387/bsd_npx.h"
 
 #define	__fenv_static
 #include <openlibm_fenv.h>

--- a/src/bsd_cdefs.h
+++ b/src/bsd_cdefs.h
@@ -93,7 +93,7 @@
  * for a given compiler, let the compile fail if it is told to use
  * a feature that we cannot live without.
  */
-#if __GNUC_PREREQ__(2, 7) || defined(__INTEL_COMPILER)
+#if !defined(__pure2) && (__GNUC_PREREQ__(2, 7) || defined(__INTEL_COMPILER))
 #define	__pure2		__attribute__((__const__))
 #endif
 

--- a/src/types-compat.h
+++ b/src/types-compat.h
@@ -3,17 +3,6 @@
 
 #include <stdint.h>
 #include <limits.h>
-#include <stdint.h>
-
-#ifdef __GLIBC__
-/* Not sure what to do about __pure2 on linux */
-#define __pure2 
-#endif
-
-#ifdef _WIN32
-/* Not sure what to do about __pure2 on windows */
-#define __pure2 
-#endif
 
 typedef uint8_t               u_int8_t;
 typedef uint16_t              u_int16_t;


### PR DESCRIPTION
The first commit fixes a warning on Fedora rawhide with GCC6. But we should check that this works on Windows.

The second commit is just a cleanup.