### PR TITLE
Fix building tests on GNU/kFreeBSD and GNU/Hurd

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ include ../Make.inc
 
 # Set rpath of tests to builddir for loading shared library
 OPENLIBM_LIB = -L.. -lopenlibm
-ifeq ($(OS),Linux)
+ifneq ($(OS), Darwin)
 OPENLIBM_LIB += -Wl,-rpath=$(OPENLIBM_HOME)
 endif
 


### PR DESCRIPTION
Since 4c8740ad589fd243eb2d3691f2c2395b505d713 -rpath is only set for $(OS) = Linux.
If setting -rpath only breaks OS X, then it may be better to set -rpath everywhere except where $(OS) = Darwin.
