### PR TITLE
WIP: Enable build on aarch64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -73,6 +73,9 @@ REAL_ARCH := $(ARCH)
 ifeq ($(findstring arm,$(ARCH)),arm)
 override ARCH := arm
 endif
+ifeq ($(ARCH),aarch64)
+override ARCH := arm
+endif
 ifeq ($(findstring powerpc,$(ARCH)),powerpc)
 override ARCH := powerpc
 endif

--- a/bsdsrc/b_tgamma.c
+++ b/bsdsrc/b_tgamma.c
@@ -128,16 +128,16 @@ tgamma(x)
 {
 	struct Double u;
 
-	if (x >= 6) {
+	if (isgreaterequal(x, 6)) {
 		if(x > 171.63)
 			return (x / zero);
 		u = large_gam(x);
 		return(__exp__D(u.a, u.b));
-	} else if (x >= 1.0 + LEFT + x0)
+	} else if (isgreaterequal(x, 1.0 + LEFT + x0))
 		return (small_gam(x));
-	else if (x > 1.e-17)
+	else if (isgreater(x, 1.e-17))
 		return (smaller_gam(x));
-	else if (x > -1.e-17) {
+	else if (isgreater(x, -1.e-17)) {
 		if (x != 0.0)
 			u.a = one - tiny;	/* raise inexact */
 		return (one/x);

--- a/include/openlibm_fenv.h
+++ b/include/openlibm_fenv.h
@@ -2,7 +2,7 @@
 #include <fenv.h>
 #else /* !OPENLIBM_USE_HOST_FENV_H */
 
-#if defined(__arm__)
+#if defined(__aarch64__) || defined(__arm__)
 #include <openlibm_fenv_arm.h>
 #elif defined(__x86_64__)
 #include <openlibm_fenv_amd64.h>

--- a/include/openlibm_fenv_arm.h
+++ b/include/openlibm_fenv_arm.h
@@ -64,7 +64,10 @@ extern const fenv_t	__fe_dfl_env;
 #define _FPUSW_SHIFT	16
 #define	_ENABLE_MASK	(FE_ALL_EXCEPT << _FPUSW_SHIFT)
 
-#ifdef	ARM_HARD_FLOAT
+#if defined(__aarch64__)
+#define __rfs(__fpsr)   __asm __volatile("mrs %0,fpsr" : "=r" (*(__fpsr)))
+#define __wfs(__fpsr)   __asm __volatile("msr fpsr,%0" : : "r" (__fpsr))
+#elif defined(ARM_HARD_FLOAT)
 #define	__rfs(__fpsr)	__asm __volatile("rfs %0" : "=r" (*(__fpsr)))
 #define	__wfs(__fpsr)	__asm __volatile("wfs %0" : : "r" (__fpsr))
 #else


### PR DESCRIPTION
This has been made much easier since recent commits by the addition of src/aarch64_fpmath.h and enabling builds for powerpc.

Mostly copied verbatim from Edmund Grimley Evans' patch in [Debian bug #803206](https://bugs.debian.org/803206).

So far, it builds and passes tests.  I haven't tried building Julia with it yet,