### PR TITLE
Update remaining references to bsd_cdefs.h to cdefs-compat.h.

### DIFF
--- a/amd64/bsd_asm.h
+++ b/amd64/bsd_asm.h
@@ -40,7 +40,7 @@
 #include "../i387/osx_asm.h"
 #define CNAME(x) EXT(x)
 #else
-#include "bsd_cdefs.h"
+#include "cdefs-compat.h"
 
 #ifdef PIC
 #define	PIC_PLT(x)	x@PLT

--- a/ld80/s_exp2l.c
+++ b/ld80/s_exp2l.c
@@ -30,7 +30,7 @@
 #include <float.h>
 #include <stdint.h>
 
-#include "bsd_cdefs.h"
+#include "cdefs-compat.h"
 #include "amd64/bsd_ieeefp.h"
 
 #include <openlibm_math.h>


### PR DESCRIPTION
It looks like we didn't substitute the name of the bsd_cdefs.h header
file in two source files when renaming it.