### PR TITLE
Version libopenlibm properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,23 @@ OBJS =  $(patsubst %.f,%.f.o,\
 	$(patsubst %.S,%.S.o,\
 	$(patsubst %.c,%.c.o,$(filter-out $(addprefix src/,$(DUPLICATE_SRCS)),$(SRCS)))))
 
+# If we're on windows, don't do versioned shared libraries.  If we're on OSX,
+# put the version number before the .dylib.  Otherwise, put it after.
+ifeq ($(OS), WINNT)
+OLM_MAJOR_MINOR_SHLIB_EXT := $(SHLIB_EXT)
+else
+ifeq ($(OS), Darwin)
+OLM_MAJOR_MINOR_SHLIB_EXT := $(SOMAJOR).$(SOMINOR).$(SHLIB_EXT)
+OLM_MAJOR_SHLIB_EXT := $(SOMAJOR).$(SHLIB_EXT)
+else
+OLM_MAJOR_MINOR_SHLIB_EXT := $(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
+OLM_MAJOR_SHLIB_EXT := $(SHLIB_EXT).$(SOMAJOR)
+endif
+endif
+
 .PHONY: all check test clean distclean install
 
-all: libopenlibm.a libopenlibm.$(SHLIB_EXT)
+all: libopenlibm.a libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT)
 
 check test: test/test-double test/test-float
 	test/test-double
@@ -37,24 +51,22 @@ check test: test/test-double test/test-float
 libopenlibm.a: $(OBJS)
 	$(AR) -rcs libopenlibm.a $(OBJS)
 
-libopenlibm.$(SHLIB_EXT): $(OBJS)
-ifeq ($(OS),WINNT)
-	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
-else
-	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(SOMAJOR) -o libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
-	ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT).$(SOMAJOR)
-	ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT)
+libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT): $(OBJS)
+	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(OLM_MAJOR_SHLIB_EXT) -o $@
+ifneq ($(OS),WINNT)
+	ln -sf $@ libopenlibm.$(OLM_MAJOR_SHLIB_EXT)
+	ln -sf $@ libopenlibm.$(SHLIB_EXT)
 endif
 
-test/test-double: libopenlibm.$(SHLIB_EXT)
+test/test-double: libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT)
 	$(MAKE) -C test test-double
 
-test/test-float: libopenlibm.$(SHLIB_EXT)
+test/test-float: libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT)
 	$(MAKE) -C test test-float
 
 clean:
 	rm -f amd64/*.o arm/*.o bsdsrc/*.o i387/*.o ld128/*.o ld80/*.o src/*.o
-	rm -f libopenlibm.a libopenlibm.$(SHLIB_EXT)*
+	rm -f libopenlibm.a libopenlibm.*$(SHLIB_EXT)*
 	$(MAKE) -C test clean
 
 openlibm.pc: openlibm.pc.in Make.inc Makefile
@@ -66,7 +78,7 @@ install: all openlibm.pc
 	mkdir -p $(DESTDIR)$(shlibdir)
 	mkdir -p $(DESTDIR)$(pkgconfigdir)
 	mkdir -p $(DESTDIR)$(includedir)/openlibm
-	cp -f -a libopenlibm.$(SHLIB_EXT)* $(DESTDIR)$(shlibdir)/
+	cp -f -a libopenlibm.*$(SHLIB_EXT)* $(DESTDIR)$(shlibdir)/
 	cp -f -a libopenlibm.a $(DESTDIR)$(libdir)/
 	cp -f -a include/*.h $(DESTDIR)$(includedir)/openlibm
 	cp -f -a src/*.h $(DESTDIR)$(includedir)/openlibm


### PR DESCRIPTION
This creates the properly named/versioned shared libraries (e.g. `libopenlibm.2.1.dylib` on OSX, `libopenlibm.so.2.1` on Linux, and just `libopenlibm.dll` on Windows).