### PR TITLE
Include missing decls for ARM

### DIFF
--- a/include/openlibm_fenv_arm.h
+++ b/include/openlibm_fenv_arm.h
@@ -31,6 +31,8 @@
 
 #include <stdint.h>
 
+#include "cdefs-compat.h"
+
 #ifndef	__fenv_static
 #define	__fenv_static	static
 #endif


### PR DESCRIPTION
Compiling on ARM fails due to missing __*_DECLS definitions. Other fenv headers have this included.