### PR TITLE
Allow setting CC

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -18,6 +18,8 @@ else
   pkgconfigdir = $(libdir)/pkgconfig
 endif
 
+ifndef CC
+
 USEGCC = 1
 USECLANG = 0
 
@@ -42,6 +44,8 @@ endif
 ifeq ($(USEGCC),1)
 CC = gcc
 CFLAGS_add += -fno-gnu89-inline -fno-builtin
+endif
+
 endif
 
 ARCH ?= $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")


### PR DESCRIPTION
This allows CC to be set when calling make, which is useful when cross compiling.

For example, on OS X, you could cross compile for Linux with `ARCH=x86_64 CC=x86_64-elf-gcc make libopenlibm.a`. Without this change, the CC passed to make is overwritten.