### PR TITLE
Fixup architecture woes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,28 @@ matrix:
                       - qemu-user-static
                       - binfmt-support
 
+        - os: linux
+          env: FLAGS="CC=arm-linux-gnueabihf-gcc" TEST_FLAGS="LDFLAGS=-static"
+          addons:
+              apt:
+                  packages:
+                      - gcc-arm-linux-gnueabihf
+                      - libc6-dev-armhf-cross
+                      - qemu-user-static
+                      - binfmt-support
+
+        # This works, but only if qemu-user-static is >= v2.4.  This is not the
+        # case on the default trusty images, so we add a PPA that has qemu 2.5
+        - os: linux
+          env: FLAGS="CC=powerpc64le-linux-gnu-gcc" TEST_FLAGS="LDFLAGS=-static"
+          addons:
+              apt:
+                  sources:
+                      - sourceline: "ppa:gns3/qemu"
+                  packages:
+                      - gcc-powerpc64le-linux-gnu
+                      - libc6-dev-ppc64el-cross
+                      - qemu-user-static
+                      - binfmt-support
 notifications:
     email: false

--- a/Make.inc
+++ b/Make.inc
@@ -1,5 +1,8 @@
 # -*- mode: makefile-gmake -*-
 
+# Default build rule for any Makefile in this project: all
+default: all
+
 OS := $(shell uname)
 # Do not forget to bump SOMINOR when changing VERSION,
 # and SOMAJOR when breaking ABI in a backward-incompatible way
@@ -13,9 +16,9 @@ libdir = $(prefix)/lib
 includedir = $(prefix)/include
 
 ifeq ($(OS), FreeBSD)
-  pkgconfigdir = $(prefix)/libdata/pkgconfig
+pkgconfigdir = $(prefix)/libdata/pkgconfig
 else
-  pkgconfigdir = $(libdir)/pkgconfig
+pkgconfigdir = $(libdir)/pkgconfig
 endif
 
 USEGCC = 1
@@ -45,36 +48,16 @@ CFLAGS_add += -fno-gnu89-inline -fno-builtin
 endif
 
 ARCH ?= $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
-ARCH_ORIGIN := $(origin ARCH)
 
 ifeq ($(ARCH),mingw32)
 $(error "the mingw32 compiler you are using fails the openblas testsuite. please see the Julia README.windows.md document for a replacement")
 endif
 
-CFLAGS_add += -std=c99 -Wall -I$(OPENLIBM_HOME) -I$(OPENLIBM_HOME)/include -I$(OPENLIBM_HOME)/ld80 -I$(OPENLIBM_HOME)/$(ARCH) -I$(OPENLIBM_HOME)/src -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration
-
-default: all
-
-# *int / *intf need to be built with -O0
-src/%int.c.o: src/%int.c
-	$(CC) $(CPPFLAGS) -O0 $(CFLAGS_add) -c $< -o $@
-
-src/%intf.c.o: src/%intf.c
-	$(CC) $(CPPFLAGS) -O0 $(CFLAGS_add) -c $< -o $@
-
-%.c.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add) -c $< -o $@
-
-%.S.o: %.S
-	$(CC) $(CPPFLAGS) $(SFLAGS) $(SFLAGS_add) $(filter -m% -B% -I% -D%,$(CFLAGS_add)) -c $< -o $@
-
 # OS-specific stuff
-REAL_ARCH := $(ARCH)
 ifeq ($(findstring arm,$(ARCH)),arm)
 override ARCH := arm
-endif
-ifeq ($(ARCH),aarch64)
-override ARCH := arm
+MARCH ?= armv7-a
+CFLAGS_add += -mhard-float
 endif
 ifeq ($(findstring powerpc,$(ARCH)),powerpc)
 override ARCH := powerpc
@@ -82,19 +65,10 @@ endif
 ifeq ($(findstring ppc,$(ARCH)),ppc)
 override ARCH := powerpc
 endif
-ifeq ($(ARCH),i386)
+ifneq ($(filter $(ARCH),i386 i486 i586 i686 i387 i487 i587 i687),)
 override ARCH := i387
+MARCH ?= i686
 endif
-ifeq ($(ARCH),i486)
-override ARCH := i387
-endif
-ifeq ($(ARCH),i586)
-override ARCH := i387
-endif
-ifeq ($(ARCH),i686)
-override ARCH := i387
-endif
-
 ifeq ($(ARCH),x86_64)
 override ARCH := amd64
 endif
@@ -109,51 +83,68 @@ override OS=WINNT
 endif
 
 #keep these if statements separate
-
 ifeq ($(OS), WINNT)
-  SHLIB_EXT = dll
-  SONAME_FLAG = -soname
-  CFLAGS_add += -nodefaultlibs
-  shlibdir = $(bindir)
+SHLIB_EXT = dll
+SONAME_FLAG = -soname
+CFLAGS_add += -nodefaultlibs
+shlibdir = $(bindir)
 else
-  ifeq ($(OS), Darwin)
-    SHLIB_EXT = dylib
-    SONAME_FLAG = -install_name
-  else
-    SHLIB_EXT = so
-    SONAME_FLAG = -soname
-  endif
-  CFLAGS_add += -fPIC
-  shlibdir = $(libdir)
+ifeq ($(OS), Darwin)
+SHLIB_EXT = dylib
+SONAME_FLAG = -install_name
+else
+SHLIB_EXT = so
+SONAME_FLAG = -soname
+endif
+CFLAGS_add += -fPIC
+shlibdir = $(libdir)
 endif
 
-# The target specific FLAGS_add
-ifeq ($(ARCH_ORIGIN),file)
-CFLAGS_add_TARGET_$(ARCH) :=
-SFLAGS_add_TARGET_$(ARCH) :=
-LDFLAGS_add_TARGET_$(ARCH) :=
-else
+# Add `-march` to our CFLAGS if it's defined
+ifneq ($(MARCH),)
+CFLAGS_arch += -march=$(MARCH)
+endif
+
 ifeq ($(ARCH),i387)
-CFLAGS_add_TARGET_$(ARCH)  := -m32 -march=$(REAL_ARCH)
-SFLAGS_add_TARGET_$(ARCH)  := -m32 -march=$(REAL_ARCH)
-LDFLAGS_add_TARGET_$(ARCH) := -m32 -march=$(REAL_ARCH)
-endif
-CFLAGS_add_TARGET_x86_64  := -m64
-SFLAGS_add_TARGET_x86_64  := -m64
-LDFLAGS_add_TARGET_x86_64 := -m64
-# Arm
-ifeq ($(ARCH),arm)
-ifneq ($(REAL_ARCH),arm)
-CFLAGS_add_TARGET_$(ARCH)  := -march=$(REAL_ARCH)
-SFLAGS_add_TARGET_$(ARCH)  := -march=$(REAL_ARCH)
-LDFLAGS_add_TARGET_$(ARCH) := -march=$(REAL_ARCH)
-else
-$(error No known generic arm cflags. Please specify arch type)
-endif
-endif
+CFLAGS_arch  += -m32
+SFLAGS_arch  += -m32
+LDFLAGS_arch += -m32
 endif
 
-# Actually finish setting the FLAGS_add
-CFLAGS_add += $(CFLAGS_add_TARGET_$(ARCH))
-LDFLAGS_add += $(LDFLAGS_add_TARGET_$(ARCH))
-SFLAGS_add += $(SFLAGS_add_TARGET_$(ARCH))
+ifeq ($(ARCH),amd64)
+CFLAGS_arch  += -m64
+SFLAGS_arch  += -m64
+LDFLAGS_arch += -m64
+endif
+
+# Add our "arch"-related FLAGS in.  We separate arch-related flags out so that
+# we can conveniently get at them for targets that don't want the rest of
+# *FLAGS_add, such as the testing Makefile targets
+CFLAGS_add  += $(CFLAGS_arch)
+SFLAGS_add  += $(SFLAGS_arch)
+LDFLAGS_add += $(LDFLAGS_arch)
+
+CFLAGS_add += -std=c99 -Wall -I$(OPENLIBM_HOME) -I$(OPENLIBM_HOME)/include -I$(OPENLIBM_HOME)/$(ARCH) -I$(OPENLIBM_HOME)/src -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration
+ifneq ($(filter $(ARCH),i387 amd64 aarch64 powerpc),)
+CFLAGS_add += -I$(OPENLIBM_HOME)/ld80
+endif
+
+
+# *int / *intf need to be built with -O0
+src/%int.c.o: src/%int.c
+	$(CC) $(CPPFLAGS) -O0 $(CFLAGS_add) -c $< -o $@
+
+src/%intf.c.o: src/%intf.c
+	$(CC) $(CPPFLAGS) -O0 $(CFLAGS_add) -c $< -o $@
+
+%.c.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add) -c $< -o $@
+
+%.S.o: %.S
+	$(CC) $(CPPFLAGS) $(SFLAGS) $(SFLAGS_add) $(filter -m% -B% -I% -D%,$(CFLAGS_add)) -c $< -o $@
+
+
+# Makefile debugging trick:
+# call print-VARIABLE to see the runtime value of any variable
+print-%:
+	@echo '$*=$($*)'

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,9 @@ OPENLIBM_HOME=$(abspath .)
 include ./Make.inc
 
 SUBDIRS = src $(ARCH) bsdsrc
-ifneq ($(ARCH), arm)
-ifneq ($(ARCH), powerpc)
+# Add ld80 directory on x86 and x64
+ifneq ($(filter $(ARCH),i387 amd64),)
 SUBDIRS += ld80
-endif
 endif
 
 define INC_template
@@ -68,7 +67,7 @@ test/test-float: libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT)
 	$(MAKE) -C test test-float
 
 clean:
-	rm -f amd64/*.o arm/*.o bsdsrc/*.o i387/*.o ld128/*.o ld80/*.o src/*.o
+	rm -f aarch64/*.o amd64/*.o arm/*.o bsdsrc/*.o i387/*.o ld80/*.o ld128/*.o src/*.o powerpc/*.o
 	rm -f libopenlibm.a libopenlibm.*$(SHLIB_EXT)*
 	$(MAKE) -C test clean
 

--- a/aarch64/Make.files
+++ b/aarch64/Make.files
@@ -1,0 +1,1 @@
+$(CUR_SRCS) = fenv.c

--- a/aarch64/fenv.c
+++ b/aarch64/fenv.c
@@ -1,0 +1,52 @@
+/*-
+ * Copyright (c) 2004 David Schultz <das@FreeBSD.ORG>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/lib/msun/arm/fenv.c,v 1.3 2011/10/16 05:37:56 das Exp $
+ */
+
+#define	__fenv_static
+#include <openlibm_fenv.h>
+
+#ifdef __GNUC_GNU_INLINE__
+#error "This file must be compiled with C99 'inline' semantics"
+#endif
+
+/*
+ * Hopefully the system ID byte is immutable, so it's valid to use
+ * this as a default environment.
+ */
+const fenv_t __fe_dfl_env = 0;
+
+extern inline int feclearexcept(int __excepts);
+extern inline int fegetexceptflag(fexcept_t *__flagp, int __excepts);
+extern inline int fesetexceptflag(const fexcept_t *__flagp, int __excepts);
+extern inline int feraiseexcept(int __excepts);
+extern inline int fetestexcept(int __excepts);
+extern inline int fegetround(void);
+extern inline int fesetround(int __round);
+extern inline int fegetenv(fenv_t *__envp);
+extern inline int feholdexcept(fenv_t *__envp);
+extern inline int fesetenv(const fenv_t *__envp);
+extern inline int feupdateenv(const fenv_t *__envp);

--- a/include/openlibm_fenv_arm.h
+++ b/include/openlibm_fenv_arm.h
@@ -69,11 +69,13 @@ extern const fenv_t	__fe_dfl_env;
 #if defined(__aarch64__)
 #define __rfs(__fpsr)   __asm __volatile("mrs %0,fpsr" : "=r" (*(__fpsr)))
 #define __wfs(__fpsr)   __asm __volatile("msr fpsr,%0" : : "r" (__fpsr))
-#elif defined(ARM_HARD_FLOAT)
-#define	__rfs(__fpsr)	__asm __volatile("rfs %0" : "=r" (*(__fpsr)))
-#define	__wfs(__fpsr)	__asm __volatile("wfs %0" : : "r" (__fpsr))
+/* Test for hardware support for ARM floating point operations, explicitly
+checking for float and double support, see "ARM C Language Extensions", 6.5.1 */
+#elif defined(__ARM_FP) && (__ARM_FP & 0x0C) != 0
+#define __rfs(__fpsr)   __asm __volatile("vmrs %0,fpscr" : "=&r" (*(__fpsr)))
+#define __wfs(__fpsr)   __asm __volatile("vmsr fpscr,%0" : : "r" (__fpsr))
 #else
-#define __rfs(__fpsr)
+#define __rfs(__fpsr)	(*(__fpsr) = 0)
 #define __wfs(__fpsr)
 #endif
 

--- a/src/Make.files
+++ b/src/Make.files
@@ -36,8 +36,8 @@ ifneq ($(OS), WINNT)
 $(CUR_SRCS) += s_nan.c
 endif
 
-ifneq ($(ARCH), arm)
-ifneq ($(ARCH), powerpc)
+# Add in long double functions for x86 and x64
+ifneq ($(filter $(ARCH),i387 amd64),)
 # C99 long double functions
 $(CUR_SRCS) +=	s_copysignl.c s_fabsl.c s_llrintl.c s_lrintl.c s_modfl.c
 
@@ -56,7 +56,6 @@ $(CUR_SRCS) +=	e_acosl.c e_asinl.c e_atan2l.c e_fmodl.c \
 	s_cimagl.c s_conjl.c s_creall.c s_cacoshl.c s_catanhl.c s_casinhl.c \
 	s_catanl.c s_csinl.c s_cacosl.c s_cexpl.c s_csinhl.c s_ccoshl.c \
 	s_clogl.c s_ctanhl.c s_ccosl.c s_cbrtl.c
-endif
 endif
 
 # C99 complex functions

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,22 +12,22 @@ all: test-double test-float # test-double-system test-float-system
 bench: bench-syslibm bench-openlibm
 
 test-double: test-double.c libm-test.c libm-test-ulps.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_arch) $(LDFLAGS) $(LDFLAGS_arch) $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
 
 test-float: test-float.c libm-test.c libm-test-ulps.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_arch) $(LDFLAGS) $(LDFLAGS_arch) $@.c -D__BSD_VISIBLE -I ../include -I../src $(OPENLIBM_LIB) -o $@
 
 test-double-system: test-double.c libm-test.c libm-test-ulps.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_arch) $(LDFLAGS) $(LDFLAGS_arch) $< -DSYS_MATH_H -lm -o $@
 
 test-float-system: test-float.c libm-test.c libm-test-ulps.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< -DSYS_MATH_H -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_arch) $(LDFLAGS) $(LDFLAGS_arch) $< -DSYS_MATH_H -lm -o $@
 
 bench-openlibm: libm-bench.cpp
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< $(OPENLIBM_LIB) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_arch) $(LDFLAGS) $(LDFLAGS_arch) $< $(OPENLIBM_LIB) -o $@
 
 bench-syslibm: libm-bench.cpp
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add_TARGET_$(ARCH)) $(LDFLAGS) $< -lm -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_arch) $(LDFLAGS) $(LDFLAGS_arch) $< -lm -o $@
 
 clean:
 	rm -fr test-double test-float test-double-system test-float-system bench-openlibm bench-syslibm *.dSYM


### PR DESCRIPTION
* Significantly cleanup `ARCH` handling.  Previously, behavior differed if the same value of `ARCH` was defined within `Make.inc` or defined on the command line.  This made me very sad.

* Fix `arm` floating-point status register code so that the tests actually work.

* Add testing for `ppc64le` and `arm` architectures on Travis through the magic of `binfmt-support` and `qemu`.

I would like to publicly thank @yuyichao for his help in debugging the arm code.