### PR TITLE
enable -fno-strict-aliasing for clang

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -39,7 +39,7 @@ AR = ar
 ifeq ($(USECLANG),1)
 USEGCC = 0
 CC = clang
-CFLAGS_add += -fno-builtin
+CFLAGS_add += -fno-builtin -fno-strict-aliasing
 endif
 
 ifeq ($(USEGCC),1)


### PR DESCRIPTION
Type punning via unions in clang is not safe without `-fno-strict-aliasing`. See https://bugs.llvm.org//show_bug.cgi?id=31928.