### PR TITLE
Allow building on DragonFly BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ consistently across compilers and operating systems, and in 32-bit and
 
 ## Platform support
 
-OpenLibm builds on Linux, Mac OS X, Windows, FreeBSD, and OpenBSD. It
-builds with both GCC and clang. Although largely tested and widely
+OpenLibm builds on Linux, Mac OS X, Windows, FreeBSD, OpenBSD, and DragonFly BSD.
+It builds with both GCC and clang. Although largely tested and widely
 used on x86 architectures, openlibm also supports ARM and
 powerPC.
 

--- a/src/s_nan.c
+++ b/src/s_nan.c
@@ -36,7 +36,7 @@
 
 #include "math_private.h"
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
 static __inline int digittoint(int c) {
 	if ('0' <= c && c <= '9')
 		return (c - '0');

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,8 +3,10 @@ include ../Make.inc
 
 # Set rpath of tests to builddir for loading shared library
 OPENLIBM_LIB = -L.. -lopenlibm
-ifneq (,$(findstring $(OS),Linux FreeBSD))
+ifneq ($(OS),WINNT)
+ifneq ($(OS),Darwin)
 OPENLIBM_LIB += -Wl,-rpath=$(OPENLIBM_HOME)
+endif
 endif
 
 all: test-double test-float # test-double-system test-float-system


### PR DESCRIPTION
The same change ~~would likely be necessary on OpenBSD as well~~ should _not_ be applied on OpenBSD.