### PR TITLE
WIP: How to speedup exp2

### DIFF
--- a/bench/build.sh
+++ b/bench/build.sh
@@ -4,6 +4,7 @@ set -e
 set -x
 
 FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
+FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -O3 -march=native -ffast-math -funroll-loops"
 
 gcc -fno-gnu89-inline -fno-builtin -O3 -fPIC -m64 -std=c99 -Wall -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
 gfortran $FFLAGS -c test_exp2.f90 -o test_exp2.o

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -3,6 +3,10 @@
 set -e
 set -x
 
-cd ..
+FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
 
-gcc -fno-gnu89-inline -fno-builtin -O3 -fPIC -m64 -std=c99 -Wall -Iinclude -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c src/s_exp2.c -o src/s_exp2.c.o
+gcc -fno-gnu89-inline -fno-builtin -O3 -fPIC -m64 -std=c99 -Wall -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
+gfortran $FFLAGS -c test_exp2.f90 -o test_exp2.o
+gfortran $FFLAGS s_exp2.c.o test_exp2.o -o test_exp2
+
+./test_exp2

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -7,12 +7,15 @@ FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
 FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -O3 -march=native -ffast-math -funroll-loops"
 
 CFLAGS="-fno-gnu89-inline -fno-builtin -fPIC -m64 -std=c99 -Wall -O3"
-gcc -flto $CFLAGS -Wno-implicit-function-declaration -c redux.c -o redux.o
+CFLAGS="$CFLAGS -march=native -funroll-loops"
+#LTO="-flto"
+gcc $LTO $CFLAGS -Wno-implicit-function-declaration -c redux.c -o redux.o
 
-#CFLAGS="$CFLAGS -march=native -ffast-math -funroll-loops"
+#CFLAGS="$CFLAGS -ffast-math"
 
-gcc -flto $CFLAGS -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
-gfortran -flto $FFLAGS -c test_exp2.f90 -o test_exp2.o
-gfortran -flto $FFLAGS s_exp2.c.o test_exp2.o redux.o -o test_exp2
+gcc $LTO $CFLAGS -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
+gcc $LTO $CFLAGS -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/e_pow.c -o e_pow.c.o
+gfortran $LTO $FFLAGS -c test_exp2.f90 -o test_exp2.o
+gfortran $LTO $FFLAGS test_exp2.o s_exp2.c.o e_pow.c.o redux.o -o test_exp2
 
 ./test_exp2

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -6,7 +6,10 @@ set -x
 FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
 FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -O3 -march=native -ffast-math -funroll-loops"
 
-gcc -fno-gnu89-inline -fno-builtin -O3 -fPIC -m64 -std=c99 -Wall -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
+CFLAGS="-fno-gnu89-inline -fno-builtin -fPIC -m64 -std=c99 -Wall -O3"
+#CFLAGS="$CFLAGS -march=native -ffast-math -funroll-loops"
+
+gcc $CFLAGS -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
 gfortran $FFLAGS -c test_exp2.f90 -o test_exp2.o
 gfortran $FFLAGS s_exp2.c.o test_exp2.o -o test_exp2
 

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -7,10 +7,12 @@ FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -g -fcheck=all -fbacktrace"
 FFLAGS="-Wall -Wextra -Wimplicit-interface -fPIC -O3 -march=native -ffast-math -funroll-loops"
 
 CFLAGS="-fno-gnu89-inline -fno-builtin -fPIC -m64 -std=c99 -Wall -O3"
+gcc -flto $CFLAGS -Wno-implicit-function-declaration -c redux.c -o redux.o
+
 #CFLAGS="$CFLAGS -march=native -ffast-math -funroll-loops"
 
-gcc $CFLAGS -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
-gfortran $FFLAGS -c test_exp2.f90 -o test_exp2.o
-gfortran $FFLAGS s_exp2.c.o test_exp2.o -o test_exp2
+gcc -flto $CFLAGS -I../include -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c ../src/s_exp2.c -o s_exp2.c.o
+gfortran -flto $FFLAGS -c test_exp2.f90 -o test_exp2.o
+gfortran -flto $FFLAGS s_exp2.c.o test_exp2.o redux.o -o test_exp2
 
 ./test_exp2

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd ..
+
+gcc -fno-gnu89-inline -fno-builtin -O3 -fPIC -m64 -std=c99 -Wall -Iinclude -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration -c src/s_exp2.c -o src/s_exp2.c.o

--- a/bench/redux.c
+++ b/bench/redux.c
@@ -1,0 +1,5 @@
+double round256(double x)
+{
+    double redux = 0x1.8p52 / 256;
+    return (x + redux) - redux;
+}

--- a/bench/test_exp2.f90
+++ b/bench/test_exp2.f90
@@ -1,0 +1,18 @@
+program test_exp2
+use iso_c_binding, only: c_double
+implicit none
+integer, parameter :: dp = kind(0.d0)
+
+interface
+    real(c_double) function c_exp2(x) bind(c, name="exp2")
+    import :: c_double
+    real(c_double), value, intent(in) :: x
+    end function
+end interface
+
+real(dp) :: y
+
+y = c_exp2(0.7_dp)
+print *, y
+
+end program

--- a/bench/test_exp2.f90
+++ b/bench/test_exp2.f90
@@ -15,7 +15,7 @@ end interface
 real(dp), allocatable :: x(:), r(:), r_exact(:), err_abs(:)
 integer, allocatable :: err_ulp(:)
 real(dp) :: t1, t2, x_min, x_max
-integer :: i, n
+integer :: i, j, n, n2
 integer, allocatable :: seed(:)
 
 call random_seed(size=n)
@@ -24,9 +24,10 @@ seed = 1
 call random_seed(put=seed)
 
 ! Used for testing:
-! n = 100000
+!n = 100000
 ! Used for benchmarking:
-n = 100000000
+n = 1000
+n2 = 100000
 allocate(x(n), r(n), r_exact(n), err_abs(n), err_ulp(n))
 
 call random_number(x)
@@ -37,7 +38,9 @@ print *, x(:10)
 print *, "Running c_exp2()"
 call cpu_time(t1)
 do i = 1, n
-    r(i) = c_exp2(x(i))
+    do j = 1, n2
+        r(i) = c_exp2(x(i))
+    end do
 end do
 call cpu_time(t2)
 print *, "Time:", t2-t1

--- a/bench/test_exp2.f90
+++ b/bench/test_exp2.f90
@@ -17,7 +17,10 @@ integer, allocatable :: err_ulp(:)
 real(dp) :: t1, t2, x_min, x_max
 integer :: i, n
 
-n = 100000
+! Used for testing:
+! n = 100000
+! Used for benchmarking:
+n = 100000000
 allocate(x(n), r(n), r_exact(n), err_abs(n), err_ulp(n))
 
 call random_number(x)

--- a/bench/test_exp2.f90
+++ b/bench/test_exp2.f90
@@ -16,6 +16,12 @@ real(dp), allocatable :: x(:), r(:), r_exact(:), err_abs(:)
 integer, allocatable :: err_ulp(:)
 real(dp) :: t1, t2, x_min, x_max
 integer :: i, n
+integer, allocatable :: seed(:)
+
+call random_seed(size=n)
+allocate(seed(n))
+seed = 1
+call random_seed(put=seed)
 
 ! Used for testing:
 ! n = 100000
@@ -27,6 +33,7 @@ call random_number(x)
 x_min = -1075
 x_max = 1024
 x = x*(x_max - x_min) + x_min
+print *, x(:10)
 print *, "Running c_exp2()"
 call cpu_time(t1)
 do i = 1, n

--- a/bench/test_exp2.f90
+++ b/bench/test_exp2.f90
@@ -1,18 +1,79 @@
 program test_exp2
 use iso_c_binding, only: c_double
+use iso_fortran_env, only: qp => real128
 implicit none
 integer, parameter :: dp = kind(0.d0)
 
 interface
     real(c_double) function c_exp2(x) bind(c, name="exp2")
+    ! The range of x is (-1075, 1024).
     import :: c_double
     real(c_double), value, intent(in) :: x
     end function
 end interface
 
-real(dp) :: y
+real(dp), allocatable :: x(:), r(:), r_exact(:), err_abs(:)
+integer, allocatable :: err_ulp(:)
+real(dp) :: t1, t2, x_min, x_max
+integer :: i, n
 
-y = c_exp2(0.7_dp)
-print *, y
+n = 100000
+allocate(x(n), r(n), r_exact(n), err_abs(n), err_ulp(n))
+
+call random_number(x)
+x_min = -1075
+x_max = 1024
+x = x*(x_max - x_min) + x_min
+print *, "Running c_exp2()"
+call cpu_time(t1)
+do i = 1, n
+    r(i) = c_exp2(x(i))
+end do
+call cpu_time(t2)
+print *, "Time:", t2-t1
+print *, "Computing Errors"
+do i = 1, n
+    r_exact(i) = real(2**real(x(i), qp), dp)
+    err_abs(i) = abs(r(i)-r_exact(i))
+    err_ulp(i) = ulp(r(i), r_exact(i))
+end do
+print *, "Done"
+print *, "Max abs error:", maxval(err_abs)
+print *, "Max ulp error:", maxval(err_ulp), "ulp"
+call histogram(err_ulp)
+
+contains
+
+    integer recursive function ulp(a, b) result(r)
+    real(dp), intent(in) :: a, b
+    r = int(abs(a - b) / spacing(abs(b)))
+    !if (r /= ulp2(a, b)) error stop
+    end function
+
+    integer recursive function ulp2(a, b) result(r)
+    real(dp), intent(in) :: a, b
+    real(dp) :: x
+    if (a > b) then
+        r = ulp2(b, a)
+        return
+    end if
+    x = nearest(a, 1.0_dp)
+    r = 0
+    if (x > b) return
+    r = 1
+    do while (x < b)
+        x = nearest(x, 1.0_dp)
+        r = r + 1
+    end do
+    end function
+
+    subroutine histogram(a)
+    integer, intent(in) :: a(:)
+    integer :: i
+    print *, "Histogram"
+    do i = 0, 4
+        print *, i, count(a == i), 100._dp * count(a == i) / size(a), "%"
+    end do
+    end subroutine
 
 end program

--- a/bench/test_exp2.f90
+++ b/bench/test_exp2.f90
@@ -10,6 +10,12 @@ interface
     import :: c_double
     real(c_double), value, intent(in) :: x
     end function
+
+    real(c_double) function c_pow(x, y) bind(c, name="ieee754_pow")
+    ! The range of x is (-1075, 1024).
+    import :: c_double
+    real(c_double), value, intent(in) :: x, y
+    end function
 end interface
 
 real(dp), allocatable :: x(:), r(:), r_exact(:), err_abs(:)
@@ -27,7 +33,10 @@ call random_seed(put=seed)
 !n = 100000
 ! Used for benchmarking:
 n = 1000
-n2 = 100000
+n2 = 10000
+
+n = 10000000
+n2 = 1
 allocate(x(n), r(n), r_exact(n), err_abs(n), err_ulp(n))
 
 call random_number(x)
@@ -39,7 +48,8 @@ print *, "Running c_exp2()"
 call cpu_time(t1)
 do i = 1, n
     do j = 1, n2
-        r(i) = c_exp2(x(i))
+        !r(i) = c_exp2(x(i))
+        r(i) = c_pow(2._dp, x(i))
     end do
 end do
 call cpu_time(t2)

--- a/src/e_pow.c
+++ b/src/e_pow.c
@@ -95,7 +95,7 @@ ivln2_h  =  1.44269502162933349609e+00, /* 0x3FF71547, 0x60000000 =24b 1/ln2*/
 ivln2_l  =  1.92596299112661746887e-08; /* 0x3E54AE0B, 0xF85DDF44 =1/ln2 tail*/
 
 OLM_DLLEXPORT double
-__ieee754_pow(double x, double y)
+ieee754_pow(double x, double y)
 {
 	double z,ax,z_h,z_l,p_h,p_l;
 	double y1,t1,t2,r,s,t,u,v,w;

--- a/src/s_exp2.c
+++ b/src/s_exp2.c
@@ -374,6 +374,7 @@ exp2(double x)
 	i0 = (i0 & (TBLSIZE - 1)) << 1;
 	//t -= redux;
 	t = round256(x);
+	//t = round(x*256)/256.;
 	z = x - t;
 
 	/* Compute r = exp2(y) = exp2t[i0] * p(z - eps[i]). */

--- a/src/s_exp2.c
+++ b/src/s_exp2.c
@@ -306,6 +306,9 @@ static const double tbl[TBLSIZE * 2] = {
 	0x1.690f4b19e9471p+0,	-0x1.9780p-45,
 };
 
+
+double round256(double x);
+
 /*
  * exp2(x): compute the base 2 exponential of x
  *
@@ -369,7 +372,8 @@ exp2(double x)
 	i0 += TBLSIZE / 2;
 	k = (i0 >> TBLBITS) << 20;
 	i0 = (i0 & (TBLSIZE - 1)) << 1;
-	t -= redux;
+	//t -= redux;
+	t = round256(x);
 	z = x - t;
 
 	/* Compute r = exp2(y) = exp2t[i0] * p(z - eps[i]). */

--- a/src/s_exp2.c
+++ b/src/s_exp2.c
@@ -314,8 +314,8 @@ static const double tbl[TBLSIZE * 2] = {
  * Method: (accurate tables)
  *
  *   Reduce x:
- *     x = 2**k + y, for integer k and |y| <= 1/2.
- *     Thus we have exp2(x) = 2**k * exp2(y).
+ *     x = k + y, for integer k and |y| <= 1/2.
+ *     Thus we have exp2(x) = 2**x = 2**k * exp2(y).
  *
  *   Reduce y:
  *     y = i/TBLSIZE + z - eps[i] for integer i near y * TBLSIZE.


### PR DESCRIPTION
This is an example pull request that shows how to speedup `exp2` using `-ffast-math` in a portable way. I don't intend this to be merged, it's just to show how to do it.
```
Original optimization level:
0.588
Original optimization + round(x*256)/256.:
0.923
Original optimization + round256(x):
0.584
-ffast-math + round(x*256)/256.:
0.667
-ffast-math + round256(x):
0.431
-ffast-math + round256(x) + no inf/nan checks:
0.375
```
I split the IEEE dependent part into a separate module and use link time optimization so that it gets inlined. The IEEE dependent part is compiled without `-ffast-math`, the rest is compiled with `-ffast-math`. The `round256(x)` does the equivalent thing as before.

The `-ffast-math` delivers significant speedup over the original optimization, as expected. The code is essentially equivalent.

For comparison, I also benchmarked using the slower but IEEE independent `round(x*256)/256.`, and with `-ffast-math`, the performance is actually not bad, but not as good as the optimized `round256()`.

Finally, I also removed all the inf/nan checks using the following patch:
```diff
--- a/src/s_exp2.c
+++ b/src/s_exp2.c
@@ -347,25 +347,6 @@ exp2(double x)
        u_int32_t hx, ix, lx, i0;
        int k;

-       /* Filter out exceptional cases. */
-       GET_HIGH_WORD(hx,x);
-       ix = hx & 0x7fffffff;           /* high word of |x| */
-       if(ix >= 0x40900000) {                  /* |x| >= 1024 */
-               if(ix >= 0x7ff00000) {
-                       GET_LOW_WORD(lx,x);
-                       if(((ix & 0xfffff) | lx) != 0 || (hx & 0x80000000) == 0)
-                               return (x + x); /* x is NaN or +Inf */
-                       else 
-                               return (0.0);   /* x is -Inf */
-               }
-               if(x >= 0x1.0p10)
-                       return (huge * huge); /* overflow */
-               if(x <= -0x1.0ccp10)
-                       return (twom1000 * twom1000); /* underflow */
-       } else if (ix < 0x3c900000) {           /* |x| < 0x1p-54 */
-               return (1.0 + x);
-       }
-
        /* Reduce x, computing z, i0, and k. */
        STRICT_ASSIGN(double, t, x + redux);
        GET_LOW_WORD(i0, t);
```
And as you can see, now we are starting to pick up some speed. The reason the benchmark is so sensitive to simple changes like that is that the function is already *very* fast.

Anyway, as you can see, I haven't done anything, just gave up IEEE compliance, but I haven't even modified any code, just moved the IEEE dependent part to a separate module, and got rid of infinities/nan checks, and now the original is more than 1.5x slower. That is a pretty heavy performance price to pay for IEEE compliance. @StefanKarpinski, you said several times that it is possible to match performance of `-ffast-math` while keeping IEEE compliance. I don't think that's true, because by getting rid of the inf/nan checks, I got significant speedup. You said there is no price to pay, but there is. But even without it, if you can match it, I would be interested in how.

I used gcc + gfortran 6.3.0 in Ubuntu 17.04 and it was ran on my laptop, the processor is Intel(R) Xeon(R) CPU E3-1505M v6 @ 3.00GHz. You are welcome to check my work, hopefully I didn't make any mistakes.