### PR TITLE
Consider:  Add TOOLPREFIX

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -34,7 +34,7 @@ USEGCC = 0
 USECLANG = 1
 endif
 
-AR = ar
+AR = $(TOOLPREFIX)ar
 
 ifeq ($(USECLANG),1)
 USEGCC = 0
@@ -43,7 +43,7 @@ CFLAGS_add += -fno-builtin -fno-strict-aliasing
 endif
 
 ifeq ($(USEGCC),1)
-CC = gcc
+CC = $(TOOLPREFIX)gcc
 CFLAGS_add += -fno-gnu89-inline -fno-builtin
 endif
 


### PR DESCRIPTION
I was trying to compile this on cygwin for a third party platform [cross] (none of the big 4).

It turns out the Make.inc sets AR static archiver and GCC assembler when in reality often an assembler/compiler will have a tool prefix, such as i686-x-gcc or in my case x86_64-elf-gcc and x86_64-elf-ar.

In my case compilation works:

TOOLPREFIX=x86_64-elf- CFLAGS="-D__ELF__ -Iinclude -I/home/bobbyjo/exa/libbasesupport/include -I/home/bobbyjo/exa/libbasesupport/include/basesupport" make USEGCC=1 ARCH=x86_64 libopenlibm.a

and I get a static library, woo!

ALTERNATIVELY you could check for CC and AR environment variables and only set when unset.