### PR TITLE
Fix reversed outputs of sincosl

### DIFF
--- a/src/s_sincosl.c
+++ b/src/s_sincosl.c
@@ -26,6 +26,6 @@
 OLM_DLLEXPORT void
 sincosl( long double x, long double * s, long double * c )
 {
-    *s = cosl( x );
-    *c = sinl( x );
+    *s = sinl( x );
+    *c = cosl( x );
 }


### PR DESCRIPTION
Hi,

I found that the outputs from sincosl are reversed.
According to man(3), the second argument is sin and the third argument is cos.

Thanks.