### PR TITLE
msun: signed overflow in atan2

### DIFF
--- a/src/e_atan2.c
+++ b/src/e_atan2.c
@@ -71,7 +71,7 @@ __ieee754_atan2(double y, double x)
 	if(((ix|((lx|-lx)>>31))>0x7ff00000)||
 	   ((iy|((ly|-ly)>>31))>0x7ff00000))	/* x or y is NaN */
 	   return x+y;
-	if(((hx-0x3ff00000)|lx)==0) return atan(y);   /* x=1.0 */
+	if(hx==0x3ff00000&&lx==0) return atan(y);   /* x=1.0 */
 	m = ((hy>>31)&1)|((hx>>30)&2);	/* 2*sign(x)+sign(y) */
 
     /* when y = 0 */


### PR DESCRIPTION
Incorporated from FreeBSD source tree: https://github.com/freebsd/freebsd/commit/b21ccf63f28a3a4692d8a31419e0a725a1b1a800. The original authorship has been preserved here. Commit message from upstream:

> As a component of atan2(y, x), the case of x == 1.0 is farmed out to
> atan(y). The current implementation of this comparison is vulnerable
> to signed integer underflow (that is, undefined behavior), and it's
> performed in a somewhat more complicated way than it need be. Change
> it to not be quite so cute, rather directly comparing the high/low
> bits of x to the specific IEEE-754 bit pattern that encodes 1.0.
>
> Note that while there are three different e_atan* files in the
> relevant directory, only this one needs fixing. e_atan2f.c already
> compares against the full bit pattern encoding 1.0f, while
> e_atan2l.cuses bitwise-ands/ors/nots and so doesn't require a change.